### PR TITLE
Improve GKE steps to deploy Graphistry on k8s

### DIFF
--- a/charts/values-overrides/examples/gke/README.md
+++ b/charts/values-overrides/examples/gke/README.md
@@ -427,7 +427,7 @@ kubectl get pods --watch -n graphistry
 ```
 
 ## Enabling Telemetry
-See [Graphistry Telemetry for Kubernetes](https://github.com/graphistry/graphistry-cli/blob/master/docs/tools/telemetry.md#kubernetes-deployment).
+See [Graphistry Telemetry for Kubernetes](https://github.com/graphistry/graphistry-cli/blob/master/docs/telemetry/kubernetes.md).
 
 ## Delete k8s cluster
 Delete the Graphistry chart:

--- a/charts/values-overrides/examples/gke/gke_values.yaml
+++ b/charts/values-overrides/examples/gke/gke_values.yaml
@@ -213,7 +213,7 @@ cuda:
   version: "11.8" #cuda version
 
 global:  ## global settings for all charts
-  tag: v2.41.10
+  tag: v2.41.15
   logs: #change log levels
       LogLevel: DEBUG #log level for the application
       GraphistryLogLevel: DEBUG #log level for graphistry


### PR DESCRIPTION
Improve the steps for GKE and update the graphistry target version to v2.41.15.