### PR TITLE
Multi node GPU support (cluster mode)

### DIFF
--- a/charts/graphistry-helm-resources/templates/default-storageclass-retain-cluster.yaml
+++ b/charts/graphistry-helm-resources/templates/default-storageclass-retain-cluster.yaml
@@ -1,0 +1,15 @@
+{{- if eq .Values.global.ENABLE_CLUSTER_MODE true  }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+  name: retain-sc-cluster
+  meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+provisioner: {{ .Values.global.provisioner }}
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  server: {{ .Values.defaultClusterStorage.nfsServer }}
+  path: {{ .Values.defaultClusterStorage.nfsPath }}   # Path on the NFS server
+{{- end }}

--- a/charts/graphistry-helm-resources/templates/default-storageclass-retain.yaml
+++ b/charts/graphistry-helm-resources/templates/default-storageclass-retain.yaml
@@ -1,4 +1,5 @@
 {{- if eq .Values.global.multiNode false  }}
+{{- if eq .Values.global.ENABLE_CLUSTER_MODE false  }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -15,4 +16,4 @@ reclaimPolicy: Retain
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
 {{- end }}
-
+{{- end }}

--- a/charts/graphistry-helm-resources/templates/default-storageclass.yaml
+++ b/charts/graphistry-helm-resources/templates/default-storageclass.yaml
@@ -1,4 +1,5 @@
 {{- if eq .Values.global.multiNode false  }}
+{{- if eq .Values.global.ENABLE_CLUSTER_MODE false  }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -16,4 +17,4 @@ reclaimPolicy: Delete
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
 {{- end }}
-
+{{- end }}

--- a/charts/graphistry-helm/templates/caddy/caddy-deployment.yaml
+++ b/charts/graphistry-helm/templates/caddy/caddy-deployment.yaml
@@ -32,7 +32,11 @@ spec:
             value: {{ .value | quote }}
    {{- end }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -80,9 +84,14 @@ spec:
               - key: Caddyfile
                 path: Caddyfile
                 mode: 0644
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/templates/dask/dask-cluster.yml
+++ b/charts/graphistry-helm/templates/dask/dask-cluster.yml
@@ -54,7 +54,11 @@ spec:
           - name: REMOTE_DASK
             value: {{.Values.daskscheduler.location | quote }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -92,9 +96,14 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -141,7 +150,11 @@ spec:
           - name: REMOTE_DASK
             value: {{.Values.daskscheduler.location | quote }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -179,9 +192,14 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount 
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/templates/dask/dask-cuda-worker-daemonset.yaml
+++ b/charts/graphistry-helm/templates/dask/dask-cuda-worker-daemonset.yaml
@@ -66,7 +66,11 @@ spec:
           - name: REMOTE_DASK
             value: {{.Values.daskscheduler.location | quote }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -113,9 +117,14 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/templates/dask/dask-scheduler-deployment.yaml
+++ b/charts/graphistry-helm/templates/dask/dask-scheduler-deployment.yaml
@@ -59,7 +59,11 @@ spec:
           - name: REMOTE_DASK
             value: {{.Values.daskscheduler.location | quote }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -100,9 +104,14 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount            
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/templates/forge-etl/forge-etl-deployment.yaml
+++ b/charts/graphistry-helm/templates/forge-etl/forge-etl-deployment.yaml
@@ -45,7 +45,11 @@ spec:
             value: {{ .value | quote }}
    {{- end }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -83,9 +87,14 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/templates/forge-etl/forge-etl-python-daemonset.yaml
+++ b/charts/graphistry-helm/templates/forge-etl/forge-etl-python-daemonset.yaml
@@ -33,6 +33,19 @@ spec:
         resources:
             {{- toYaml .Values.InitContainerResources | nindent 10 }}
       - name: "forge-etl-python-wait-for-postgres"
+      {{ if eq .Values.global.IS_FOLLOWER true }}
+        image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.5-1
+        command:
+          - "sh"
+          - "-c"
+          - |
+            echo "Waiting for PostgreSQL to be ready..."
+            until pg_isready -h {{ .Values.global.POSTGRES_HOST }} -p 5432; do
+              echo "PostgreSQL not ready, waiting 5 seconds...";
+              sleep 5;
+            done;
+            echo "PostgreSQL is up!";
+      {{ else }}
         {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
         image: "groundnuty/k8s-wait-for:latest" #DockerHub
         {{ else }}
@@ -44,6 +57,7 @@ spec:
         args: 
         - "pod"
         - "-lapp=postgres"
+      {{- end }}
       containers:
         - env:
           - name: GRAPHISTRY_CPU_MODE
@@ -74,7 +88,11 @@ spec:
           - name: FORGE_MAX_FILE_WAIT_MS
             value: {{.Values.ForgeMaxFileWait | quote }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -119,12 +137,19 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+        - name: uploads-files
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount
         - name: uploads-files
           persistentVolumeClaim:
             claimName: uploads-files
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/templates/graph-app-kit/graph-app-kit-private-deployment.yaml
+++ b/charts/graphistry-helm/templates/graph-app-kit/graph-app-kit-private-deployment.yaml
@@ -93,9 +93,14 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: gak-private
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: gak-private
           persistentVolumeClaim:
             claimName: gak-private
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/templates/graph-app-kit/graph-app-kit-public-deployment.yaml
+++ b/charts/graphistry-helm/templates/graph-app-kit/graph-app-kit-public-deployment.yaml
@@ -93,9 +93,14 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: gak-public
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: gak-public
           persistentVolumeClaim:
             claimName: gak-public
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/templates/nexus/nexus-deployment.yaml
+++ b/charts/graphistry-helm/templates/nexus/nexus-deployment.yaml
@@ -27,6 +27,19 @@ spec:
     spec:
       initContainers:
       - name: "nexus-wait-for-postgres"
+      {{ if eq .Values.global.IS_FOLLOWER true }}
+        image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.5-1
+        command:
+          - "sh"
+          - "-c"
+          - |
+            echo "Waiting for PostgreSQL to be ready..."
+            until pg_isready -h {{ .Values.global.POSTGRES_HOST }} -p 5432; do
+              echo "PostgreSQL not ready, waiting 5 seconds...";
+              sleep 5;
+            done;
+            echo "PostgreSQL is up!";
+      {{ else }}
         {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
         image: "groundnuty/k8s-wait-for:latest" #DockerHub
         {{ else }}
@@ -38,6 +51,7 @@ spec:
         args: 
         - "pod"
         - "-lapp=postgres"
+      {{- end }}
       containers:
         - env:
           - name: GRAPHISTRY_CPU_MODE
@@ -65,7 +79,11 @@ spec:
             value: {{ .value | quote }}
    {{- end }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -149,12 +167,19 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: local-media-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: local-media-mount
           persistentVolumeClaim:
             claimName: local-media-mount
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/templates/nginx/nginx-deployment.yaml
+++ b/charts/graphistry-helm/templates/nginx/nginx-deployment.yaml
@@ -125,7 +125,11 @@ spec:
             value: {{ .value | quote }}
    {{- end }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -236,6 +240,14 @@ spec:
         {{- end }}
         - name: pivot-static
           emptyDir: {}           
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: local-media-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+        - name: uploads-files
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: local-media-mount
           persistentVolumeClaim:
             claimName: local-media-mount
@@ -245,6 +257,7 @@ spec:
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount
+      {{- end }}
         - name: exporter-config
           configMap:
             name: exporter-config

--- a/charts/graphistry-helm/templates/notebook/notebook-deployment.yaml
+++ b/charts/graphistry-helm/templates/notebook/notebook-deployment.yaml
@@ -59,7 +59,11 @@ spec:
             value: "default"
         {{- end }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -109,6 +113,14 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+        - name: gak-public
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+        - name: gak-private
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount
@@ -118,6 +130,7 @@ spec:
         - name: gak-private
           persistentVolumeClaim:
             claimName: gak-private
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/templates/pivot/pivot-deployment.yaml
+++ b/charts/graphistry-helm/templates/pivot/pivot-deployment.yaml
@@ -27,6 +27,19 @@ spec:
     spec:
       initContainers:
       - name: "pivot-wait-for-postgres"
+      {{ if eq .Values.global.IS_FOLLOWER true }}
+        image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.5-1
+        command:
+          - "sh"
+          - "-c"
+          - |
+            echo "Waiting for PostgreSQL to be ready..."
+            until pg_isready -h {{ .Values.global.POSTGRES_HOST }} -p 5432; do
+              echo "PostgreSQL not ready, waiting 5 seconds...";
+              sleep 5;
+            done;
+            echo "PostgreSQL is up!";
+      {{ else }}
         {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
         image: "groundnuty/k8s-wait-for:latest" #DockerHub
         {{ else }}
@@ -38,6 +51,7 @@ spec:
         args: 
         - "pod"
         - "-lapp=postgres"
+      {{- end }}
       - name: "pivot-wait-for-nexus"
         {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
         image: "groundnuty/k8s-wait-for:latest" #DockerHub
@@ -79,7 +93,11 @@ spec:
             value: {{ .value | quote }}
    {{- end }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -127,9 +145,14 @@ spec:
             items:
               - key: config.json
                 path: config.json
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount
+      {{- end }}
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       {{- with .Values.global.imagePullSecrets }}

--- a/charts/graphistry-helm/templates/pvc/data-mount-persistentvolumeclaim.yaml
+++ b/charts/graphistry-helm/templates/pvc/data-mount-persistentvolumeclaim.yaml
@@ -19,6 +19,10 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: datamount-longhorn
+{{- else if eq .Values.global.ENABLE_CLUSTER_MODE true  }}
+  accessModes:
+    - "ReadWriteMany"
+  storageClassName: {{ .Values.global.storageClassNameOverride | default "retain-sc-cluster" }}
 {{- else }}
   accessModes:
     - ReadWriteOnce

--- a/charts/graphistry-helm/templates/pvc/gak-private-persistentvolumeclaim.yaml
+++ b/charts/graphistry-helm/templates/pvc/gak-private-persistentvolumeclaim.yaml
@@ -26,6 +26,10 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: datamount-longhorn
+{{- else if eq .Values.global.ENABLE_CLUSTER_MODE true  }}
+  accessModes:
+    - "ReadWriteMany"
+  storageClassName: {{ .Values.global.storageClassNameOverride | default "retain-sc-cluster" }}
 {{- else }}
   accessModes:
     - ReadWriteOnce

--- a/charts/graphistry-helm/templates/pvc/gak-public-persistentvolumeclaim.yaml
+++ b/charts/graphistry-helm/templates/pvc/gak-public-persistentvolumeclaim.yaml
@@ -27,6 +27,10 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: datamount-longhorn
+{{- else if eq .Values.global.ENABLE_CLUSTER_MODE true  }}
+  accessModes:
+    - "ReadWriteMany"
+  storageClassName: {{ .Values.global.storageClassNameOverride | default "retain-sc-cluster" }}
 {{- else }}
   accessModes:
     - ReadWriteOnce

--- a/charts/graphistry-helm/templates/pvc/local-media-mount-persistentvolumeclaim.yaml
+++ b/charts/graphistry-helm/templates/pvc/local-media-mount-persistentvolumeclaim.yaml
@@ -22,6 +22,10 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: datamount-longhorn
+{{- else if eq .Values.global.ENABLE_CLUSTER_MODE true  }}
+  accessModes:
+    - "ReadWriteMany"
+  storageClassName: {{ .Values.global.storageClassNameOverride | default "retain-sc-cluster" }}
 {{- else }}
   accessModes:
     - ReadWriteOnce

--- a/charts/graphistry-helm/templates/pvc/uploads-files-persistentvolumeclaim.yaml
+++ b/charts/graphistry-helm/templates/pvc/uploads-files-persistentvolumeclaim.yaml
@@ -22,6 +22,10 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: datamount-longhorn
+{{- else if eq .Values.global.ENABLE_CLUSTER_MODE true  }}
+  accessModes:
+    - "ReadWriteMany"
+  storageClassName: {{ .Values.global.storageClassNameOverride | default "retain-sc-cluster" }}
 {{- else }}
   accessModes:
     - ReadWriteOnce

--- a/charts/graphistry-helm/templates/redis/redis-deployment.yaml
+++ b/charts/graphistry-helm/templates/redis/redis-deployment.yaml
@@ -33,7 +33,11 @@ spec:
             value: {{ .value | quote }}
    {{- end }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -73,9 +77,14 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/templates/streamgl/streamgl-gpu-daemonset.yaml
+++ b/charts/graphistry-helm/templates/streamgl/streamgl-gpu-daemonset.yaml
@@ -46,7 +46,11 @@ spec:
           - name: REMOTE_DASK
             value: {{.Values.daskscheduler.location | quote }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -88,9 +92,14 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/templates/streamgl/streamgl-sessions-deployment.yaml
+++ b/charts/graphistry-helm/templates/streamgl/streamgl-sessions-deployment.yaml
@@ -32,7 +32,11 @@ spec:
             value: {{ .value | quote }}
    {{- end }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -74,9 +78,14 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/templates/streamgl/streamgl-vgraph-etl-deployment.yaml
+++ b/charts/graphistry-helm/templates/streamgl/streamgl-vgraph-etl-deployment.yaml
@@ -34,7 +34,11 @@ spec:
             value: {{ .value | quote }}
    {{- end }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -72,9 +76,14 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/templates/streamgl/streamgl-viz-deployment.yaml
+++ b/charts/graphistry-helm/templates/streamgl/streamgl-viz-deployment.yaml
@@ -27,6 +27,19 @@ spec:
     spec:
       initContainers:
       - name: "streamgl-viz-wait-for-postgres"
+      {{ if eq .Values.global.IS_FOLLOWER true }}
+        image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.5-1
+        command:
+          - "sh"
+          - "-c"
+          - |
+            echo "Waiting for PostgreSQL to be ready..."
+            until pg_isready -h {{ .Values.global.POSTGRES_HOST }} -p 5432; do
+              echo "PostgreSQL not ready, waiting 5 seconds...";
+              sleep 5;
+            done;
+            echo "PostgreSQL is up!";
+      {{ else }}
         {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
         image: "groundnuty/k8s-wait-for:latest" #DockerHub
         {{ else }}
@@ -38,6 +51,7 @@ spec:
         args: 
         - "pod"
         - "-lapp=postgres"
+      {{- end }}
       - name: "streamgl-viz-wait-for-redis"
         {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
         image: "groundnuty/k8s-wait-for:latest" #DockerHub
@@ -64,7 +78,11 @@ spec:
             value: {{ .value | quote }}
    {{- end }}
           - name: POSTGRES_HOST
+          {{ if eq .Values.global.IS_FOLLOWER true }}
+            value: {{ .Values.global.POSTGRES_HOST | quote }}
+          {{ else }}
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: host } }
+          {{- end }}
           - name: POSTGRES_PORT
             valueFrom: { secretKeyRef: { name: {{.Values.global.postgres.host }}-pguser-{{.Values.global.postgres.user }}, key: port } }
           - name: POSTGRES_DB
@@ -106,9 +124,14 @@ spec:
       restartPolicy: {{ .Values.global.restartPolicy }}
       serviceAccountName: job-robot
       volumes:
+      {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+        - name: data-mount
+{{- toYaml .Values.global.clusterVolume | nindent 10 }}
+      {{ else }}
         - name: data-mount
           persistentVolumeClaim:
             claimName: data-mount
+      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/graphistry-helm/values.yaml
+++ b/charts/graphistry-helm/values.yaml
@@ -451,6 +451,10 @@ global:  ## global settings for all charts
     GraphistryLogLevel: INFO #log level for graphistry
   ENABLE_OPEN_TELEMETRY: false
 
+  # Cluster deployment settings
+  ENABLE_CLUSTER_MODE: false
+  IS_FOLLOWER: false
+
 #environment variables 
  # can be set like helm install chart_name --name release_name \
  #--set env.DBUser="FOO" --set env.DBPassword="BAR"

--- a/charts/postgres-cluster/templates/postgres-cluster.yaml
+++ b/charts/postgres-cluster/templates/postgres-cluster.yaml
@@ -49,6 +49,10 @@ spec:
         accessModes:
           - "ReadWriteMany"
         storageClassName: postgres-longhorn
+      {{- else if and (eq .Values.global.ENABLE_CLUSTER_MODE true) (not .Values.global.IS_FOLLOWER) }}
+        accessModes:
+          - "ReadWriteMany"
+        storageClassName: {{ .Values.global.storageClassNameOverride | default "retain-sc-cluster" }}
       {{- else }}
         accessModes:
           - "ReadWriteOnce"
@@ -86,6 +90,10 @@ spec:
               accessModes:
                 - "ReadWriteMany"
               storageClassName: postgres-longhorn-{{ .Release.Namespace }}
+            {{- else if eq .Values.global.ENABLE_CLUSTER_MODE true  }}
+              accessModes:
+                - "ReadWriteMany"
+              storageClassName: {{ .Values.global.storageClassNameOverride | default "retain-sc-cluster" }}
             {{- else }}
               accessModes:
                 - "ReadWriteOnce"

--- a/charts/postgres-cluster/values.yaml
+++ b/charts/postgres-cluster/values.yaml
@@ -1,4 +1,8 @@
 global:
+  # Cluster deployment settings
+  ENABLE_CLUSTER_MODE: false
+  IS_FOLLOWER: false
+
    #- Each StorageClass has a provisioner that determines what volume plugin is used for provisioning PVs.
   provisioner: kubernetes.io/aws-ebs #storage class provisioner
   multiNode: false # multinode selector switch to determine if going multi/single node


### PR DESCRIPTION
This PR implements cluster mode for Graphistry on K8s:
1. Each Graphistry instance (the `leader` and the `followers`) will be deployed in their own namespace.
2. All instances will share access to the same volume (this PR implements a distributed storage backend using `NFS` as reference).
3. All instances will point to the `leader` `Postgres` DB instance, and thus use the same DB.