### PR TITLE
Fix PR #76 review issues

### DIFF
--- a/charts/graphistry-helm/charts/telemetry/values.yaml
+++ b/charts/graphistry-helm/charts/telemetry/values.yaml
@@ -39,7 +39,7 @@ global:  ## global settings for all charts
   # Telemetry documentation:
   # https://github.com/graphistry/graphistry-cli/blob/master/docs/tools/telemetry.md#kubernetes-deployment
   telemetryStack:
-    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials bellow
+    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials below
     openTelemetryCollector:
       image: "otel/opentelemetry-collector-contrib:0.87.0"
       # Settings for cloud mode (when OTEL_CLOUD_MODE: true)

--- a/charts/graphistry-helm/templates/pvc/data-mount-persistentvolumeclaim.yaml
+++ b/charts/graphistry-helm/templates/pvc/data-mount-persistentvolumeclaim.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.global.ENABLE_CLUSTER_MODE false }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -20,16 +19,19 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: datamount-longhorn
+{{- else if eq .Values.global.ENABLE_CLUSTER_MODE true  }}
+  accessModes:
+    - "ReadWriteMany"
+  storageClassName: {{ .Values.global.storageClassNameOverride | default "retain-sc-cluster" }}
 {{- else }}
   accessModes:
     - ReadWriteOnce
   storageClassName: {{ .Values.global.storageClassNameOverride | default "retain-sc" }}
-{{- end }}  
+{{- end }}
 {{- if .Values.volumeName.dataMount }}
   volumeName: {{ .Values.volumeName.dataMount }}
 {{- end }}
   resources:
-    requests: 
+    requests:
       storage: 64Gi
 status: {}
-{{- end }}

--- a/charts/graphistry-helm/templates/pvc/local-media-mount-persistentvolumeclaim.yaml
+++ b/charts/graphistry-helm/templates/pvc/local-media-mount-persistentvolumeclaim.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.global.ENABLE_CLUSTER_MODE false }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -23,6 +22,10 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: datamount-longhorn
+{{- else if eq .Values.global.ENABLE_CLUSTER_MODE true  }}
+  accessModes:
+    - "ReadWriteMany"
+  storageClassName: {{ .Values.global.storageClassNameOverride | default "retain-sc-cluster" }}
 {{- else }}
   accessModes:
     - ReadWriteOnce
@@ -35,4 +38,3 @@ spec:
     requests:
       storage: 4Gi
 status: {}
-{{- end }}

--- a/charts/graphistry-helm/templates/pvc/uploads-files-persistentvolumeclaim.yaml
+++ b/charts/graphistry-helm/templates/pvc/uploads-files-persistentvolumeclaim.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.global.ENABLE_CLUSTER_MODE false }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -23,14 +22,16 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: datamount-longhorn
+{{- else if eq .Values.global.ENABLE_CLUSTER_MODE true  }}
+  accessModes:
+    - "ReadWriteMany"
+  storageClassName: {{ .Values.global.storageClassNameOverride | default "retain-sc-cluster" }}
 {{- else }}
   accessModes:
     - ReadWriteOnce
   storageClassName: {{ .Values.global.storageClassNameOverride | default "retain-sc" }}
 {{- end }}
-  #volumeName: pvc-8147f3f6-9b84-4974-b2bb-298a6395ad5a
   resources:
     requests:
       storage: 40Gi
 status: {}
-{{- end }}

--- a/charts/values-overrides/examples/cluster/global-common.yaml
+++ b/charts/values-overrides/examples/cluster/global-common.yaml
@@ -5,9 +5,9 @@ global:  ## global settings for all charts
   ENABLE_OPEN_TELEMETRY: true
 
   telemetryStack:
-    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials bellow
+    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials below
 
-# Log levels: INFO (default), DEBUG, TRACE (for troubleshooting)
-logs:
+  # Log levels: INFO (default), DEBUG, TRACE (for troubleshooting)
+  logs:
     LogLevel: INFO
     GraphistryLogLevel: INFO

--- a/charts/values-overrides/examples/gke/gke_example_values.yaml
+++ b/charts/values-overrides/examples/gke/gke_example_values.yaml
@@ -59,7 +59,7 @@ global:
   # Telemetry stack configuration
   # Documentation: https://github.com/graphistry/graphistry-cli/blob/master/docs/tools/telemetry.md#kubernetes-deployment
   telemetryStack:
-    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials bellow
+    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials below
     openTelemetryCollector:
       OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT: ""   # e.g. Grafana OTLP HTTP endpoint for Graphistry Hub https://otlp-gateway-prod-us-east-0.grafana.net/otlp
       OTEL_COLLECTOR_OTLP_USERNAME: ""   # e.g. Grafana Cloud Instance ID for OTLP

--- a/charts/values-overrides/examples/k3s/k3s_example_values.yaml
+++ b/charts/values-overrides/examples/k3s/k3s_example_values.yaml
@@ -1,11 +1,12 @@
 tls: false
 
-#volume pv names go here after initial deployment and provisioning
+# Optional: pin PVCs to specific PVs after initial deployment.
+# Get volume names with: kubectl get pvc -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.volumeName}{"\n"}{end}'
 volumeName:
-  dataMount: pvc-6327f91b-8c7f-4644-93b1-e3eb6f79b49a
-  localMediaMount: pvc-76680b21-4688-4c81-a79e-b01317a6f4db
-  gakPublic: pvc-fbcee9c7-c985-4c73-8f79-74943eae87a3
-  gakPrivate: pvc-7e49e1e1-de5f-4847-821b-041d4376d941
+  dataMount: ""
+  localMediaMount: ""
+  gakPublic: ""
+  gakPrivate: ""
 
 ## createServiceAccount: true only true on initial deployment
 k8sDashboard:

--- a/charts/values-overrides/examples/tanzu/tanzu_example_values.yaml
+++ b/charts/values-overrides/examples/tanzu/tanzu_example_values.yaml
@@ -31,7 +31,8 @@ global:
   # by the cluster admin with reclaimPolicy: Retain to preserve data across redeployments.
   # When empty, defaults to "retain-sc" (single-node) or "retain-sc-cluster" (cluster mode).
   # Example: storageClassNameOverride: "vsphere-sc"
-  storageClassNameOverride: "vsphere-sc"
+  # Must match the StorageClass name created in the README (Option A creates "retain-sc")
+  storageClassNameOverride: "retain-sc"
 
   # Node selector for GPU nodes
   # Check available labels with: kubectl get nodes --show-labels
@@ -55,7 +56,7 @@ global:
   # Telemetry stack configuration
   # Documentation: https://github.com/graphistry/graphistry-cli/blob/master/docs/tools/telemetry.md#kubernetes-deployment
   telemetryStack:
-    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials bellow
+    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials below
     openTelemetryCollector:
       OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT: ""   # e.g. Grafana OTLP HTTP endpoint for Graphistry Hub https://otlp-gateway-prod-us-east-0.grafana.net/otlp
       OTEL_COLLECTOR_OTLP_USERNAME: ""   # e.g. Grafana Cloud Instance ID for OTLP

--- a/charts/values-overrides/examples/tanzu/tanzu_example_values.yaml
+++ b/charts/values-overrides/examples/tanzu/tanzu_example_values.yaml
@@ -32,6 +32,7 @@ global:
   # When empty, defaults to "retain-sc" (single-node) or "retain-sc-cluster" (cluster mode).
   # Example: storageClassNameOverride: "vsphere-sc"
   # Must match the StorageClass name created in the README (Option A creates "retain-sc")
+  # Note: "retain-sc" is already the default — set to "" or remove to use the default, or set a custom SC name
   storageClassNameOverride: "retain-sc"
 
   # Node selector for GPU nodes


### PR DESCRIPTION
## Summary
- **StorageClass cluster-mode consistency**: Added cluster-mode branching (`retain-sc-cluster` default) to `data-mount`, `local-media-mount`, and `uploads-files` PVC templates, matching the existing pattern in `gak-public`/`gak-private` and `postgres-cluster`
- **Fix logs indentation**: Moved `logs:` from root level to under `global:` in `cluster/global-common.yaml` so log levels are no longer silently ignored
- **Tanzu SC name mismatch**: Changed `storageClassNameOverride` from `"vsphere-sc"` to `"retain-sc"` to match README Option A
- **k3s hardcoded UUIDs**: Cleared cluster-specific PVC UUIDs from the example, added comment explaining they're optional
- **Typo fix**: `bellow` → `below` in `global-common.yaml`, `gke_example_values.yaml`, `tanzu_example_values.yaml`

## Verification
- `helm template --debug` in single-node mode: all 5 PVCs use `retain-sc`
- `helm template --debug` in cluster mode (`ENABLE_CLUSTER_MODE=true`): all 5 PVCs use `retain-sc-cluster`

## Test plan
- [ ] `helm template` single-node mode confirms `retain-sc` on all PVCs
- [ ] `helm template` cluster mode confirms `retain-sc-cluster` on all PVCs
- [ ] `helm template` with `storageClassNameOverride` set confirms override applies everywhere
- [ ] Verify `logs:` block is properly nested under `global:` in cluster example

🤖 Generated with [Claude Code](https://claude.com/claude-code)