### PR TITLE
v0.4.2: upgrade to RAPIDS 26.02, CUDA 12/13 flavors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 *   Working on fixing the Top level persistence for jupyter Notebooks, currently it is persistent inside the different directories but top level resets on redeployment.
 
+## [Version 0.4.2 - 2026-03-26]
+
+### Changed
+
+- RAPIDS upgrade: 25.02 -> 26.02. Graphistry v2.50.0+ now uses RAPIDS 26.02, which officially supports both CUDA 12 and CUDA 13 driver ranges. This resolves incompatibilities with NVIDIA driver 580.x that affected RAPIDS 25.02 (cudf pinned `cuda-python<13.0a0`).
+- CUDA flavors: Replaced CUDA 12.8 and CUDA 11.8 image variants with CUDA 12 and CUDA 13 flavors. The `cuda.version` chart value now accepts `"12"` or `"13"` (previously `"12.8"` or `"11.8"`). CUDA 12 uses RAPIDS base image with CUDA 12.9.1 toolkit (driver R575+ recommended). CUDA 13 uses RAPIDS base image with CUDA 13.1.0 toolkit (driver R590+ required).
+- Dropped CUDA 11 support.
+- Default CUDA version: `12.8` -> `12` in base values.yaml.
+- Default image tag: `v2.45.11` -> `v2.50.0` in base values.yaml, all example values, and Sphinx docs.
+- Driver compatibility tables: Updated across all platform READMEs (k3s, GKE, Tanzu), troubleshooting guide, and Sphinx docs (10mins-to-k8s.rst, graphistry-helm-docs.rst, values-override.rst) with new RAPIDS 26.02 driver requirements, verified driver versions, and references to RAPIDS Platform Support (https://docs.rapids.ai/platform-support/).
+- GKE GPU driver section: Restructured to note that Google's pre-built driver DaemonSets currently go up to R570. Users should check https://github.com/GoogleCloudPlatform/container-engine-accelerators for newer versions (R575+, R590+).
+- k3s KUBECONFIG setup: Replaced `/etc/profile.d/` approach (only works for login shells) with `~/.bashrc` (works for all terminal windows). Added alternatives table covering per-session, per-user, `/etc/environment`, and `/etc/profile.d/` options.
+- k3s GPU verification: Replaced `kubectl run --rm -it` (fails silently on first image pull) with `kubectl run` + `kubectl wait --timeout=300s` + `kubectl logs` pattern that handles image pull delays.
+- k3s helm repo add: Added `--force-update` flag so the command is idempotent (no error if repo already exists).
+- k3s redeployment: Added stale PV `claimRef` troubleshooting section explaining the common scenario where `helm uninstall` + reinstall with `reclaimPolicy: Retain` leaves orphaned PVs.
+- Charts version: graphistry-helm 0.4.1 -> 0.4.2.
+
 ## [Version 0.4.1 - 2026-02-05]
 
 ### Removed

--- a/charts/graphistry-helm/Chart.yaml
+++ b/charts/graphistry-helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: Graphistry-Helm-Chart
-version: 0.4.1
+version: 0.4.2
 apiVersion: v1
 description: >
  Helm Charts to deploy Graphistry to kubernetes for 100x visualizations
@@ -91,7 +91,7 @@ long_description: |
 
           global:
               provisioner: <your-csi-provisioner>
-              tag: v2.45.11
+              tag: v2.50.0
               storageClassNameOverride: ""
               nodeSelector:
                 nvidia.com/gpu.present: "true"

--- a/charts/graphistry-helm/values.yaml
+++ b/charts/graphistry-helm/values.yaml
@@ -279,7 +279,7 @@ longhornDashboard: false #enables longhorn dashboard - needs longhorn installed
 
 #cuda version
 cuda:
-  version: "12.8" #cuda version
+  version: "12" #cuda version: "12" or "13"
 
 
 #caddy repository name
@@ -404,7 +404,7 @@ global:  ## global settings for all charts
     user: graphistry
     port: 5432
     host: postgres
-  tag: v2.45.11
+  tag: v2.50.0
   imagePullPolicy: IfNotPresent
   restartPolicy: Always
   imagePullSecrets: []

--- a/charts/values-overrides/examples/azure_example_values.yaml
+++ b/charts/values-overrides/examples/azure_example_values.yaml
@@ -20,7 +20,7 @@ graphistryResources:
 
 
 global:
-  tag: v2.45.11
+  tag: v2.50.0
   provisioner: disk.csi.azure.com
   containerregistry:
     name: 

--- a/charts/values-overrides/examples/cluster/global-common.yaml
+++ b/charts/values-overrides/examples/cluster/global-common.yaml
@@ -1,5 +1,5 @@
 global:  ## global settings for all charts
-  tag: v2.45.11
+  tag: v2.50.0
   ENABLE_CLUSTER_MODE: true
   # Telemetry: https://graphistry-admin-docs.readthedocs.io/en/latest/telemetry/kubernetes.html
   ENABLE_OPEN_TELEMETRY: true

--- a/charts/values-overrides/examples/gke/README.md
+++ b/charts/values-overrides/examples/gke/README.md
@@ -98,7 +98,7 @@ gcloud beta container clusters create demo-cluster \
 ```
 
 - `--accelerator type=nvidia-tesla-t4,count=1`: Attaches 1 Tesla T4 GPU to each node.
-- `gpu-driver-version=disabled`: Disables GKE's automatic GPU driver installation so we can install the R570 driver manually via DaemonSet (see next step). GKE's `default` installs R535 (CUDA 12.2 max) and `latest` installs R580 (CUDA 13.x only, not backward compatible with CUDA 12.x).
+- `gpu-driver-version=disabled`: Disables GKE's automatic GPU driver installation so we can install the driver manually via DaemonSet (see next step). GKE's `default` installs R535 and `latest` installs R580. For Graphistry's CUDA 12 build (driver 535+) the R570 DaemonSet is recommended; for the CUDA 13 build (driver 590+) you need an R590+ driver.
 - `--image-type "UBUNTU_CONTAINERD"`: Ubuntu is required because Google provides a pre-built [R570 driver DaemonSet](https://github.com/GoogleCloudPlatform/container-engine-accelerators/blob/master/nvidia-driver-installer/ubuntu/daemonset-preloaded-R570.yaml) for Ubuntu but not for COS.
 - `--machine-type "n1-highmem-8"`: 8 vCPUs / 52 GB RAM. T4 GPUs [only attach to N1 machines](https://docs.cloud.google.com/compute/docs/gpus) (max 24 vCPUs with 1 T4). The `n1-highmem-4` (4 vCPUs) is too small — the PostgreSQL Operator (PGO) reserves ~1 CPU with Guaranteed QoS, and backup CronJobs need additional CPU to schedule. With 4 vCPUs the node runs at ~96% CPU, causing backup pods to stay Pending and block all downstream services.
 
@@ -129,7 +129,11 @@ Check the resources:
 kubectl get all
 ```
 
-## Install NVIDIA R570 GPU Driver (For CUDA 12.8)
+## Install NVIDIA GPU Driver
+
+The recommended driver for Graphistry's CUDA 12 flavor is R575+ and for CUDA 13 is R590+ (see driver compatibility table above). However, Google's pre-built [driver DaemonSets](https://github.com/GoogleCloudPlatform/container-engine-accelerators/tree/master/nvidia-driver-installer/ubuntu) currently only go up to R570. Check that repository for newer versions before proceeding. If R575+ or R590+ are not yet available, R570 may work with the CUDA 12 flavor via NVIDIA's [forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) layer.
+
+### Install R570 Driver DaemonSet (CUDA 12)
 
 With `gpu-driver-version=disabled`, the GPU driver must be installed manually. Google provides a pre-built [R570 DaemonSet](https://github.com/GoogleCloudPlatform/container-engine-accelerators/blob/master/nvidia-driver-installer/ubuntu/daemonset-preloaded-R570.yaml) for Ubuntu, but it hardcodes driver version `570.124.06` which may not have a pre-built package for your node's kernel version.
 
@@ -167,7 +171,7 @@ Verify the driver is installed:
 kubectl logs -n kube-system -l k8s-app=nvidia-driver-installer -c nvidia-driver-installer --tail=20
 ```
 
-**Why R570?** CUDA 12.x requires driver >=525 and <580 ([NVIDIA CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/)). GKE's available driver options (`default`=R535, `latest`=R580) either cap at CUDA 12.2 or only support CUDA 13.x. R570 is the correct choice for CUDA 12.8.
+**Why R570?** R570 is the newest driver available in Google's pre-built [driver DaemonSets](https://github.com/GoogleCloudPlatform/container-engine-accelerators/tree/master/nvidia-driver-installer/ubuntu). GKE's built-in driver options (`default`=R535, `latest`=R580) do not match our recommended R575+ for CUDA 12 or R590+ for CUDA 13. R570 works with Graphistry's CUDA 12 flavor via NVIDIA's forward compatibility layer. Check the repository for newer DaemonSets (R575+, R590+) as they become available.
 
 ## Setup the NVIDIA GPU Operator
 Create the namespace:
@@ -237,7 +241,7 @@ helm install --wait --generate-name \
 ```
 
 Notes:
-1. `driver.enabled=false`: The R570 DaemonSet manages the GPU driver (570.124.06 for CUDA 12.8). The [NVIDIA GPU Operator Component Matrix](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html#gpu-operator-component-matrix) lists supported driver versions.
+1. `driver.enabled=false`: The R570 DaemonSet manages the GPU driver. The [NVIDIA GPU Operator Component Matrix](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html#gpu-operator-component-matrix) lists supported driver versions.
 2. `RUNTIME_CONFIG_SOURCE=file` is required for GKE's containerd 2.0+ (config v3 format).
 3. `NVIDIA_RUNTIME_SET_AS_DEFAULT=true` makes nvidia the default container runtime, so all pods get GPU access without explicit `nvidia.com/gpu` resource requests (equivalent to k3s `--default-runtime nvidia`).
 
@@ -463,13 +467,22 @@ kubectl get pods --watch -n graphistry
 **Note**: If pods stay in `Pending` state, verify the StorageClass is correctly configured (see [Configure StorageClass](#configure-storageclass)).
 
 ## Install Graphistry
-Graphistry publishes Docker images for both CUDA 12.8 and CUDA 11.8. The `cuda.version` chart value selects which image variant to pull (e.g., `graphistry/nexus:v2.45.11-12.8`). You can set the CUDA and Graphistry versions by editing `./charts/values-overrides/examples/gke/gke_example_values.yaml`:
+Graphistry v2.50.0+ uses RAPIDS 26.02 and publishes Docker images in two flavors: CUDA 12 and CUDA 13. The `cuda.version` chart value accepts `"12"` or `"13"` and selects which image variant to pull (e.g., `graphistry/nexus:v2.50.0-12`). Internally, Graphistry builds on top of RAPIDS base images (`rapidsai/base:26.02-cuda12-py3.10` and `rapidsai/base:26.02-cuda13-py3.10`), which ship specific CUDA toolkit versions that determine the minimum driver requirement:
+
+| Graphistry Build | RAPIDS | CUDA Toolkit in Image | Recommended Min Driver | Verified On |
+|---|---|---|---|---|
+| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | driver 575.57.08 (CUDA 12.9), driver 580.126.20 (CUDA 13.0) |
+| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | driver 590.48.01 (CUDA 13.1) |
+
+We recommend the driver versions in the table above. Older drivers may work via NVIDIA's [forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) layer but are not verified by Graphistry. The CUDA 13 flavor requires R590+ because the RAPIDS 26.02 base image (`rapidsai/base:26.02-cuda13-py3.10`) bakes CUDA 13.1 runtime (`CUDA_VERSION=13.1.0`), not 13.0. See the [RAPIDS Platform Support](https://docs.rapids.ai/platform-support/) matrix and [NVIDIA CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/) for the full driver compatibility matrix.
+
+You can set the CUDA and Graphistry versions by editing `./charts/values-overrides/examples/gke/gke_example_values.yaml`:
 ```yaml
 cuda:
-  version: "12.8"   # or "11.8" - must match the GPU driver installed above
+  version: "12"   # or "13" - must match the GPU driver installed above
 
 global:  ## global settings for all charts
-  tag: v2.45.11
+  tag: v2.50.0
 ```
 
 Also verify that the values file references the correct Docker Hub pull secret ([Create Docker Hub Secret](#create-docker-hub-secret)) and StorageClass configuration ([Configure StorageClass](#configure-storageclass)):
@@ -642,6 +655,6 @@ For comprehensive troubleshooting, debugging, and verification commands covering
 
 **DCGM profiling error on COS nodes**: The DCGM profiling module is incompatible with GKE Container-Optimized OS (COS). If `dcgm-exporter` is in CrashLoopBackOff, apply the configmap patch that disables profiling metrics (see the DCGM fix section earlier in this guide).
 
-**GKE GPU driver version**: GKE auto-installs GPU drivers by default. If you need a specific driver version (e.g., R570 for CUDA 12.8), use `--gpu-driver-version=disabled` at cluster creation and install the driver manually via DaemonSet (see the R570 Driver Install section earlier in this guide).
+**GKE GPU driver version**: GKE auto-installs GPU drivers by default. If you need a specific driver version (e.g., R575+ for CUDA 12 or R590+ for CUDA 13), use `--gpu-driver-version=disabled` at cluster creation and install the driver manually via DaemonSet (see the GPU Driver Install section earlier in this guide).
 
 **n1-highmem-4 resource pressure**: PGO backup pods may stay Pending on `n1-highmem-4` instances due to insufficient CPU. Use `n1-highmem-8` or larger.

--- a/charts/values-overrides/examples/gke/README.md
+++ b/charts/values-overrides/examples/gke/README.md
@@ -103,7 +103,14 @@ gcloud beta container clusters create demo-cluster \
 - `--machine-type "n1-highmem-8"`: 8 vCPUs / 52 GB RAM. T4 GPUs [only attach to N1 machines](https://docs.cloud.google.com/compute/docs/gpus) (max 24 vCPUs with 1 T4). The `n1-highmem-4` (4 vCPUs) is too small — the PostgreSQL Operator (PGO) reserves ~1 CPU with Guaranteed QoS, and backup CronJobs need additional CPU to schedule. With 4 vCPUs the node runs at ~96% CPU, causing backup pods to stay Pending and block all downstream services.
 
 ## Get cluster credentials
-The next command should fill the credentials in `~/.kube/config`:
+
+If you have other Kubernetes installations on this machine (e.g., k3s, minikube), make sure `KUBECONFIG` points to the GKE config file so credentials and contexts don't conflict:
+
+```bash
+export KUBECONFIG=~/.kube/config
+```
+
+Then fetch the GKE cluster credentials:
 ```bash
 USE_GKE_GCLOUD_AUTH_PLUGIN=True \
     gcloud container clusters get-credentials demo-cluster --zone us-central1-a
@@ -471,8 +478,8 @@ Graphistry v2.50.0+ uses RAPIDS 26.02 and publishes Docker images in two flavors
 
 | Graphistry Build | RAPIDS | CUDA Toolkit in Image | Recommended Min Driver | Verified On |
 |---|---|---|---|---|
-| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | driver 575.57.08 (CUDA 12.9), driver 580.126.20 (CUDA 13.0) |
-| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | driver 590.48.01 (CUDA 13.1) |
+| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | GKE: R570 (570.133.20, T4, forward compat). k3s: R575 (575.57.08), R580 (580.126.20), R590 (590.44.01) |
+| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | k3s: R590 (590.44.01). Docker compose: R590 (590.48.01) |
 
 We recommend the driver versions in the table above. Older drivers may work via NVIDIA's [forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) layer but are not verified by Graphistry. The CUDA 13 flavor requires R590+ because the RAPIDS 26.02 base image (`rapidsai/base:26.02-cuda13-py3.10`) bakes CUDA 13.1 runtime (`CUDA_VERSION=13.1.0`), not 13.0. See the [RAPIDS Platform Support](https://docs.rapids.ai/platform-support/) matrix and [NVIDIA CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/) for the full driver compatibility matrix.
 

--- a/charts/values-overrides/examples/gke/gke_example_values.yaml
+++ b/charts/values-overrides/examples/gke/gke_example_values.yaml
@@ -23,7 +23,7 @@ k8sDashboard:
   createServiceAccount: false
 
 cuda:
-  version: "12.8"
+  version: "12"
 
 global:
   # GKE storage provisioner
@@ -41,7 +41,7 @@ global:
     nvidia.com/gpu.present: "true"
 
   # Graphistry version
-  tag: v2.45.11
+  tag: v2.50.0
 
   # Image settings
   imagePullPolicy: Always

--- a/charts/values-overrides/examples/k3s/README.md
+++ b/charts/values-overrides/examples/k3s/README.md
@@ -30,16 +30,23 @@ Replace `<your-group>` with the OS group whose members should have kubectl acces
 | `--write-kubeconfig-group <group>` | Sets the group owner of `/etc/rancher/k3s/k3s.yaml` |
 | `--node-name <name>` | Sets a custom node name instead of the hostname |
 
-Set up KUBECONFIG so `kubectl` and `helm` work in all sessions:
+Set up KUBECONFIG so `kubectl` and `helm` work as a non-root user. The recommended approach is per-user via your shell's rc file since it is permanent and under the control of the user running the deployment:
 
 ```bash
-# Make KUBECONFIG available for all users on login
-cat > /etc/profile.d/k3s-env.sh << 'EOF'
-export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-EOF
+# Recommended: per-user, permanent for all new terminal windows
+# Use ~/.bashrc for bash, ~/.zshrc for zsh, or ~/.config/fish/config.fish for fish
+echo 'export KUBECONFIG=/etc/rancher/k3s/k3s.yaml' >> ~/.bashrc
+source ~/.bashrc
 ```
 
-> **Note:** Open a new terminal session (or run `source /etc/profile.d/k3s-env.sh`) for the KUBECONFIG to take effect.
+Other alternatives:
+
+| Method | Command | Scope |
+|--------|---------|-------|
+| Current session only | `export KUBECONFIG=/etc/rancher/k3s/k3s.yaml` | This terminal only, lost on close |
+| Per user (recommended) | Add `export KUBECONFIG=/etc/rancher/k3s/k3s.yaml` to `~/.bashrc`, `~/.zshrc`, etc. | All new terminal windows for this user |
+| All users, all sessions | Add `KUBECONFIG=/etc/rancher/k3s/k3s.yaml` to `/etc/environment` | Every new session (terminal, SSH, graphical) |
+| All users, login shells only | Add `export KUBECONFIG=/etc/rancher/k3s/k3s.yaml` to `/etc/profile.d/k3s-env.sh` | SSH and `bash --login` only, not desktop terminals |
 
 Install Helm if not already present:
 
@@ -56,7 +63,9 @@ kubectl get nodes -o wide
 
 ### Option 1: NVIDIA GPU Operator (Recommended)
 ```bash
-helm repo add nvidia https://helm.ngc.nvidia.com/nvidia && helm repo update
+helm repo add nvidia https://helm.ngc.nvidia.com/nvidia --force-update
+
+helm repo update
 
 # Operator installs the NVIDIA driver on the node
 helm install --wait --generate-name \
@@ -74,14 +83,14 @@ helm install --wait --generate-name \
     --timeout 60m
 ```
 
-Graphistry publishes Docker images for both CUDA 12.8 and CUDA 11.8. The `cuda.version` chart value selects which image variant to pull (e.g., `graphistry/nexus:v2.45.11-12.8`). The GPU driver must be compatible with the chosen CUDA version:
+Graphistry v2.50.0+ uses RAPIDS 26.02 and publishes Docker images in two flavors: CUDA 12 and CUDA 13. The `cuda.version` chart value accepts `"12"` or `"13"` and selects which image variant to pull (e.g., `graphistry/nexus:v2.50.0-12`). Internally, Graphistry builds on top of RAPIDS base images (`rapidsai/base:26.02-cuda12-py3.10` and `rapidsai/base:26.02-cuda13-py3.10`), which ship specific CUDA toolkit versions that determine the minimum driver requirement:
 
-| CUDA Version | Minimum Driver | Recommended `driver.version` | Notes |
-|---|---|---|---|
-| 12.8 | >=570.26 | `570.195.03` | R570 branch or newer |
-| 11.8 | >=520.61.05 | `535.288.01` | R535 branch or newer |
+| Graphistry Build | RAPIDS | CUDA Toolkit in Image | Recommended Min Driver | Verified On |
+|---|---|---|---|---|
+| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | driver 575.57.08 (CUDA 12.9), driver 580.126.20 (CUDA 13.0) |
+| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | driver 590.48.01 (CUDA 13.1) |
 
-The chart default is `cuda.version: "12.8"`. If using CUDA 11.8, add `--set cuda.version="11.8"` to your Graphistry helm install command (the [Install Graphistry](#install-graphistry) step, not the GPU Operator). See the [NVIDIA CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/) for the full driver compatibility matrix.
+We recommend the driver versions in the table above. Older drivers may work via NVIDIA's [forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) layer but are not verified by Graphistry. The chart default is `cuda.version: "12"`. The CUDA 13 flavor requires R590+ because the RAPIDS 26.02 base image (`rapidsai/base:26.02-cuda13-py3.10`) bakes CUDA 13.1 runtime (`CUDA_VERSION=13.1.0`), not 13.0. See the [RAPIDS Platform Support](https://docs.rapids.ai/platform-support/) matrix and [NVIDIA CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/) for the full driver compatibility matrix.
 
 Wait for the operator pods to be ready:
 ```bash
@@ -127,14 +136,20 @@ Example output (in case of 2 GPUs):
 }
 ```
 
-Test that a GPU container can actually run (uses a temporary pod that cleans up after itself):
+Test that a GPU container can actually run (creates a temporary pod, waits for the image to pull, and cleans up after itself):
 
 ```bash
-kubectl run gpu-test --rm -it --restart=Never \
-    --image=nvidia/cuda:12.8.0-base-ubuntu22.04 -- nvidia-smi
+(GPU_TEST_POD=graphistry-gpu-test-$$; \
+  kubectl delete pod $GPU_TEST_POD --ignore-not-found && \
+  kubectl run $GPU_TEST_POD --restart=Never --image=nvidia/cuda:12.8.0-base-ubuntu24.04 -- nvidia-smi && \
+  kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/$GPU_TEST_POD --timeout=300s && \
+  kubectl logs $GPU_TEST_POD; \
+  kubectl delete pod $GPU_TEST_POD --ignore-not-found)
 ```
 
-Expected output: nvidia-smi table showing your GPU model, driver version, and CUDA version. The driver must be in the compatible range for Graphistry's CUDA 12.8 images (driver 525-579). See the [troubleshooting guide](../troubleshooting.md#2-gpu-support) for the full driver compatibility table.
+Note: the first run may take a few minutes while the CUDA image is pulled. The `kubectl wait` handles this automatically with a 5 minute timeout.
+
+Expected output: nvidia-smi table showing your GPU model, driver version, and CUDA version. The driver must be in the compatible range for your chosen Graphistry CUDA build: 535+ for CUDA 12, 590+ for CUDA 13. See the [troubleshooting guide](../troubleshooting.md#2-gpu-support) for the full driver compatibility table.
 
 ## Get Graphistry Helm Charts
 
@@ -302,13 +317,13 @@ kubectl get pods --watch -n graphistry
 
 ## Install Graphistry
 
-Graphistry publishes Docker images for both CUDA 12.8 and CUDA 11.8. The `cuda.version` chart value selects which image variant to pull (e.g., `graphistry/nexus:v2.45.11-12.8`). You can set the CUDA and Graphistry versions by editing `./charts/values-overrides/examples/k3s/k3s_example_values.yaml`:
+You can set the CUDA and Graphistry versions by editing `./charts/values-overrides/examples/k3s/k3s_example_values.yaml` (see the driver compatibility table in the [GPU Support](#option-1-nvidia-gpu-operator-recommended) section above for accepted `cuda.version` values and driver requirements):
 ```yaml
 cuda:
-  version: "12.8"   # or "11.8" - must match the GPU driver installed above
+  version: "13"   # or "12" - must match the GPU driver installed above
 
 global:  ## global settings for all charts
-  tag: v2.45.11
+  tag: v2.50.0
 ```
 
 Also verify that the values file references the correct Docker Hub pull secret ([Create Docker Hub Secret](#create-docker-hub-secret)) and StorageClass configuration ([Configure StorageClass](#configure-storageclass)):
@@ -380,6 +395,16 @@ helm upgrade -i g-chart ./charts/graphistry-helm \
     --values ./charts/values-overrides/examples/k3s/k3s_example_values.yaml \
     --namespace graphistry --create-namespace
 ```
+
+If pods stay in `Pending` state after a reinstall, the PVs may have a stale `claimRef`. This commonly happens when you `helm uninstall` the Graphistry chart and then reinstall it: the StorageClass uses `reclaimPolicy: Retain`, so the PVs survive the uninstall but remain bound to the old (now deleted) PVCs. The new PVCs cannot bind to those PVs until the stale `claimRef` is cleared:
+
+```bash
+kubectl get pv -o json | \
+    jq -r '.items[] | select(.status.phase=="Released") | select(.spec.claimRef.namespace=="graphistry") | .metadata.name' | \
+    xargs -I {} kubectl patch pv {} -p '{"spec":{"claimRef": null}}'
+```
+
+Then re-run the helm upgrade. The PVCs will bind to the existing PVs via the `volumeName` field, preserving your data. For more details, see the [Troubleshooting Guide](../troubleshooting.md#troubleshoot-and-debug-9).
 
 ## Enabling Telemetry
 

--- a/charts/values-overrides/examples/k3s/README.md
+++ b/charts/values-overrides/examples/k3s/README.md
@@ -87,8 +87,8 @@ Graphistry v2.50.0+ uses RAPIDS 26.02 and publishes Docker images in two flavors
 
 | Graphistry Build | RAPIDS | CUDA Toolkit in Image | Recommended Min Driver | Verified On |
 |---|---|---|---|---|
-| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | driver 575.57.08 (CUDA 12.9), driver 580.126.20 (CUDA 13.0) |
-| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | driver 590.48.01 (CUDA 13.1) |
+| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | k3s: R575 (575.57.08), R580 (580.126.20), R590 (590.44.01). GKE: R570 (570.133.20, T4, forward compat) |
+| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | k3s: R590 (590.44.01). Docker compose: R590 (590.48.01) |
 
 We recommend the driver versions in the table above. Older drivers may work via NVIDIA's [forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) layer but are not verified by Graphistry. The chart default is `cuda.version: "12"`. The CUDA 13 flavor requires R590+ because the RAPIDS 26.02 base image (`rapidsai/base:26.02-cuda13-py3.10`) bakes CUDA 13.1 runtime (`CUDA_VERSION=13.1.0`), not 13.0. See the [RAPIDS Platform Support](https://docs.rapids.ai/platform-support/) matrix and [NVIDIA CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/) for the full driver compatibility matrix.
 
@@ -149,7 +149,7 @@ Test that a GPU container can actually run (creates a temporary pod, waits for t
 
 Note: the first run may take a few minutes while the CUDA image is pulled. The `kubectl wait` handles this automatically with a 5 minute timeout.
 
-Expected output: nvidia-smi table showing your GPU model, driver version, and CUDA version. The driver must be in the compatible range for your chosen Graphistry CUDA build: 535+ for CUDA 12, 590+ for CUDA 13. See the [troubleshooting guide](../troubleshooting.md#2-gpu-support) for the full driver compatibility table.
+Expected output: nvidia-smi table showing your GPU model, driver version, and CUDA version. The driver must be in the compatible range for your chosen Graphistry CUDA build: R575+ for CUDA 12 (R570+ via forward compat), R590+ for CUDA 13. See the [troubleshooting guide](../troubleshooting.md#2-gpu-support) for the full driver compatibility table.
 
 ## Get Graphistry Helm Charts
 

--- a/charts/values-overrides/examples/k3s/k3s_example_values.yaml
+++ b/charts/values-overrides/examples/k3s/k3s_example_values.yaml
@@ -270,11 +270,14 @@ graphAppKitPrivate: true # graph app kit private - determines if private dashboa
 
 forgeWorkers: "1" #sets the number of forge workers recommend 1 per 4 GB GPU memory
 
-# CUDA version - 12.8 supports modern GPUs including Blackwell
+# CUDA version - 12 or 13
 cuda:
-  version: "12.8"
+  version: "12"
 
 global:  ## global settings for all charts
+  # Graphistry version: Your Docker Hub account must have access to Graphistry images (Contact Graphistry Support: https://www.graphistry.com/support to get access).
+  tag: v2.50.0
+
   # For new K8s versions (e.g. GKE) that don't need anymore the legacy annotation kubernetes.io/ingress.class: traefik
   ingressClassName: traefik
 
@@ -304,7 +307,6 @@ global:  ## global settings for all charts
     user: graphistry #db user
     port: 5432 #port for postgres service to listen on
     host: postgres #hostname for postgres
-  tag: v2.45.11
 
   imagePullPolicy: Always   #image pull policy could also be Always
   restartPolicy: Always #restart policy

--- a/charts/values-overrides/examples/tanzu/README.md
+++ b/charts/values-overrides/examples/tanzu/README.md
@@ -194,8 +194,8 @@ Graphistry v2.50.0+ uses RAPIDS 26.02 and publishes Docker images in two flavors
 
 | Graphistry Build | RAPIDS | CUDA Toolkit in Image | Recommended Min Driver | Verified On |
 |---|---|---|---|---|
-| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | driver 575.57.08 (CUDA 12.9), driver 580.126.20 (CUDA 13.0) |
-| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | driver 590.48.01 (CUDA 13.1) |
+| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | k3s: R575 (575.57.08), R580 (580.126.20), R590 (590.44.01). GKE: R570 (570.133.20, T4, forward compat) |
+| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | k3s: R590 (590.44.01). Docker compose: R590 (590.48.01) |
 
 We recommend the driver versions in the table above. Older drivers may work via NVIDIA's [forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) layer but are not verified by Graphistry. The chart default is `cuda.version: "12"`. The CUDA 13 flavor requires R590+ because the RAPIDS 26.02 base image (`rapidsai/base:26.02-cuda13-py3.10`) bakes CUDA 13.1 runtime (`CUDA_VERSION=13.1.0`), not 13.0. See the [RAPIDS Platform Support](https://docs.rapids.ai/platform-support/) matrix, [NVIDIA CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/) for the full driver compatibility matrix, and the [GPU Operator Component Matrix](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html#gpu-operator-component-matrix) for supported driver versions per operator release.
 
@@ -279,8 +279,8 @@ For environments with limited or no internet access, update your values file:
 global:
   # Redirect image pulls to your private registry
   # Images are pulled as: <containerregistry.name>/<image>:<tag>
-  # Default: docker.io/graphistry (e.g., docker.io/graphistry/nexus:v2.45.11)
-  # Air-gapped: my-registry.local/graphistry (e.g., my-registry.local/graphistry/nexus:v2.45.11)
+  # Default: docker.io/graphistry (e.g., docker.io/graphistry/nexus:v2.50.0-12)
+  # Air-gapped: my-registry.local/graphistry (e.g., my-registry.local/graphistry/nexus:v2.50.0-12)
   containerregistry:
     name: my-private-registry.local/graphistry
 

--- a/charts/values-overrides/examples/tanzu/README.md
+++ b/charts/values-overrides/examples/tanzu/README.md
@@ -190,14 +190,14 @@ helm install --wait --generate-name \
 
 **Choose `<DRIVER_VERSION>` based on your CUDA version:**
 
-Graphistry publishes Docker images for both CUDA 12.8 and CUDA 11.8. The `cuda.version` chart value selects which image variant to pull (e.g., `graphistry/nexus:v2.45.11-12.8` vs `graphistry/nexus:v2.45.11-11.8`). The GPU driver installed on the node must be compatible with the chosen CUDA version:
+Graphistry v2.50.0+ uses RAPIDS 26.02 and publishes Docker images in two flavors: CUDA 12 and CUDA 13. The `cuda.version` chart value accepts `"12"` or `"13"` and selects which image variant to pull (e.g., `graphistry/nexus:v2.50.0-12`). Internally, Graphistry builds on top of RAPIDS base images (`rapidsai/base:26.02-cuda12-py3.10` and `rapidsai/base:26.02-cuda13-py3.10`), which ship specific CUDA toolkit versions that determine the minimum driver requirement:
 
-| CUDA Version | Minimum Driver | Recommended `driver.version` | Notes |
-|---|---|---|---|
-| 12.8 | >=570.26 | `570.195.03` | R570 branch or newer |
-| 11.8 | >=520.61.05 | `535.288.01` | R535 branch or newer |
+| Graphistry Build | RAPIDS | CUDA Toolkit in Image | Recommended Min Driver | Verified On |
+|---|---|---|---|---|
+| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | driver 575.57.08 (CUDA 12.9), driver 580.126.20 (CUDA 13.0) |
+| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | driver 590.48.01 (CUDA 13.1) |
 
-The chart default is `cuda.version: "12.8"`. If using CUDA 11.8, add `--set cuda.version="11.8"` to your Graphistry helm install command (the [Install Graphistry](#install-graphistry) step, not the GPU Operator). See the [NVIDIA CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/) for the full driver compatibility matrix and the [GPU Operator Component Matrix](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html#gpu-operator-component-matrix) for supported driver versions per operator release.
+We recommend the driver versions in the table above. Older drivers may work via NVIDIA's [forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) layer but are not verified by Graphistry. The chart default is `cuda.version: "12"`. The CUDA 13 flavor requires R590+ because the RAPIDS 26.02 base image (`rapidsai/base:26.02-cuda13-py3.10`) bakes CUDA 13.1 runtime (`CUDA_VERSION=13.1.0`), not 13.0. See the [RAPIDS Platform Support](https://docs.rapids.ai/platform-support/) matrix, [NVIDIA CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/) for the full driver compatibility matrix, and the [GPU Operator Component Matrix](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html#gpu-operator-component-matrix) for supported driver versions per operator release.
 
 Notes:
 1. `driver.enabled=true`: The GPU Operator installs the NVIDIA driver on Tanzu nodes (unlike GKE which uses a separate DaemonSet).
@@ -452,13 +452,13 @@ kubectl get pods --watch -n graphistry
 
 ## Install Graphistry
 
-Graphistry publishes Docker images for both CUDA 12.8 and CUDA 11.8. The `cuda.version` chart value selects which image variant to pull (e.g., `graphistry/nexus:v2.45.11-12.8`). You can set the CUDA and Graphistry versions by editing `./charts/values-overrides/examples/tanzu/tanzu_example_values.yaml`:
+You can set the CUDA and Graphistry versions by editing `./charts/values-overrides/examples/tanzu/tanzu_example_values.yaml`:
 ```yaml
 cuda:
-  version: "12.8"   # or "11.8" - must match the GPU driver installed above
+  version: "12"   # or "13" - must match the GPU driver installed above
 
 global:  ## global settings for all charts
-  tag: v2.45.11
+  tag: v2.50.0
 ```
 
 Also verify that the values file references the correct Docker Hub pull secret ([Create Docker Hub Secret](#create-docker-hub-secret)) and StorageClass configuration ([Configure StorageClass](#configure-storageclass)):

--- a/charts/values-overrides/examples/tanzu/tanzu_example_values.yaml
+++ b/charts/values-overrides/examples/tanzu/tanzu_example_values.yaml
@@ -42,7 +42,7 @@ global:
     nvidia.com/gpu.present: "true"
 
   # Graphistry version
-  tag: v2.45.11
+  tag: v2.50.0
 
   # Image settings
   imagePullPolicy: Always

--- a/charts/values-overrides/examples/troubleshooting.md
+++ b/charts/values-overrides/examples/troubleshooting.md
@@ -339,11 +339,10 @@ kubectl exec -n gpu-operator $(kubectl get pods -n gpu-operator -o name | grep d
 
 This confirms the driver is functional and shows the GPU model, driver version, CUDA version, memory, and temperature. If this command fails, the driver is not working correctly and must be fixed before proceeding. See [Troubleshoot and Debug](#troubleshoot-and-debug-1) below.
 
-Verify the GPU is usable by Graphistry CUDA containers. The previous step confirmed the GPU Operator pods can access the GPU. This step verifies that a standalone CUDA container can also use it, which is how Graphistry services run. Graphistry supports CUDA 11.8 and CUDA 12.8, so the test pod uses one of these CUDA base images. CUDA 13 support will be part of future releases.
+Verify the GPU is usable by Graphistry CUDA containers. The previous step confirmed the GPU Operator pods can access the GPU. This step verifies that a standalone CUDA container can also use it, which is how Graphistry services run. Graphistry v2.50.0+ supports CUDA 12 and CUDA 13 (see driver compatibility table below).
 
 ```bash
-# Graphistry supports CUDA 11.8 and 12.8, you can test with any version in that range (try using CUDA_VERSION=12.8.0 or CUDA_VERSION=11.8.0).
-# CUDA 13 support will be part of future releases.
+# Graphistry supports CUDA 12 (driver 535+) and CUDA 13 (driver 590+). Test with the version matching your driver.
 (CUDA_VERSION=12.8.0; GPU_TEST_POD=graphistry-gpu-test-$$; \
   kubectl delete pod $GPU_TEST_POD --ignore-not-found && \
   kubectl run $GPU_TEST_POD --restart=Never --image=nvidia/cuda:${CUDA_VERSION}-base-ubuntu22.04 -- nvidia-smi && \
@@ -377,18 +376,20 @@ pod "graphistry-gpu-test-3407611" deleted from default namespace
 
 > **Note (Tanzu vGPU):** In vGPU mode, nvidia-smi will show the **vGPU profile name** instead of the physical GPU model (e.g., `NVIDIA A100-4C` instead of `NVIDIA A100-PCIE-40GB`), and memory will reflect the vGPU allocation, not the full physical GPU memory. It will also display a `vGPU Software License Status` line showing `Licensed` (with expiry) or `Unlicensed`. If it shows `Unlicensed`, verify the licensing secret (`gridd.conf` and `client_configuration_token.tok`) in the `gpu-operator` namespace. See the [Tanzu README](tanzu/README.md) for vGPU licensing setup.
 
-**Driver compatibility for Graphistry CUDA images** (source: [CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/)):
+**Driver compatibility for Graphistry v2.50.0+ CUDA images** (sources: [RAPIDS Platform Support](https://docs.rapids.ai/platform-support/), [CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/)):
 
-| Graphistry CUDA Image | Min Driver (Linux) | Recommended Driver | Compatible Driver Range |
-|---|---|---|---|
-| 12.8 | >= 570.26 | 570.124.06+ (R570 branch) | >= 525 and < 580 |
-| 11.8 | >= 520.61.05 | 535.288.01+ (R535 branch) | >= 450 and < 525 |
+Graphistry v2.50.0+ uses RAPIDS 26.02 and publishes two flavors: CUDA 12 and CUDA 13. The `cuda.version` chart value accepts `"12"` or `"13"`. Internally, Graphistry builds on top of RAPIDS base images (`rapidsai/base:26.02-cuda12-py3.10` and `rapidsai/base:26.02-cuda13-py3.10`), which ship specific CUDA toolkit versions that determine the minimum driver requirement:
 
-The "Compatible Driver Range" column reflects NVIDIA's [minor version compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) guarantee: within the same CUDA major version, any driver in that range is guaranteed to run applications compiled for that CUDA version. Drivers outside the upper bound (e.g., a CUDA 13 driver >= 580 running CUDA 12.x apps) are not covered by this formal guarantee.
+| Graphistry Build | RAPIDS | CUDA Toolkit in Image | Recommended Min Driver | Verified On |
+|---|---|---|---|---|
+| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | driver 575.57.08 (CUDA 12.9), driver 580.126.20 (CUDA 13.0) |
+| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | driver 590.48.01 (CUDA 13.1) |
 
-For example, driver 575.57.08 (reporting CUDA 12.9 in nvidia-smi) falls within the 525-579 range, so it is fully compatible with Graphistry's CUDA 12.8 images.
+We recommend the driver versions in the table above. Older drivers may work via NVIDIA's [forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) layer but are not verified by Graphistry.
 
-> **Warning:** CUDA 13 drivers (>= 580) introduce a new major version boundary. NVIDIA's minor version compatibility guarantee does **not** extend across major versions. Graphistry's current CUDA 12.8 and 11.8 images are **not compatible** with CUDA 13 drivers. Do not upgrade your GPU driver to >= 580 until you are running a Graphistry release with CUDA 13 support. CUDA 13 support is in active internal development and will be included in a future Graphistry release. Always consult the [CUDA Compatibility Guide](https://docs.nvidia.com/deploy/cuda-compatibility/) and the [CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/) before upgrading drivers.
+The CUDA 13 flavor requires R590+ because the RAPIDS 26.02 base image (`rapidsai/base:26.02-cuda13-py3.10`) bakes CUDA 13.1 runtime (`CUDA_VERSION=13.1.0`), not 13.0. Drivers in the R580 range support CUDA 13.0 but not 13.1, so they are compatible with the CUDA 12 flavor only.
+
+For example, driver 580.126.20 (reporting CUDA 13.0 in nvidia-smi) works with Graphistry's CUDA 12 build but fails with the CUDA 13 build because CUDA 13.1 requires R590+.
 
 **NVIDIA reference documentation:**
 

--- a/charts/values-overrides/examples/troubleshooting.md
+++ b/charts/values-overrides/examples/troubleshooting.md
@@ -382,8 +382,8 @@ Graphistry v2.50.0+ uses RAPIDS 26.02 and publishes two flavors: CUDA 12 and CUD
 
 | Graphistry Build | RAPIDS | CUDA Toolkit in Image | Recommended Min Driver | Verified On |
 |---|---|---|---|---|
-| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | driver 575.57.08 (CUDA 12.9), driver 580.126.20 (CUDA 13.0) |
-| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | driver 590.48.01 (CUDA 13.1) |
+| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | k3s: R575 (575.57.08), R580 (580.126.20), R590 (590.44.01). GKE: R570 (570.133.20, T4, forward compat) |
+| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | k3s: R590 (590.44.01). Docker compose: R590 (590.48.01) |
 
 We recommend the driver versions in the table above. Older drivers may work via NVIDIA's [forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) layer but are not verified by Graphistry.
 

--- a/docs/source/10mins-to-k8s.rst
+++ b/docs/source/10mins-to-k8s.rst
@@ -43,16 +43,18 @@ GPU Operator (Recommended)
 
 Set ``--set driver.enabled=true`` and ``--set driver.version="<VERSION>"`` if the NVIDIA driver is not already installed on the host.
 
-Graphistry publishes images for both CUDA 12.8 and CUDA 11.8. The GPU driver must be compatible with the chosen CUDA version:
+Graphistry v2.50.0+ uses RAPIDS 26.02 and publishes images in two flavors: CUDA 12 and CUDA 13. The ``cuda.version`` chart value accepts ``"12"`` or ``"13"``. The GPU driver must be compatible with the chosen CUDA version:
 
-======== ============= ======================== =====
-CUDA     Min Driver    Recommended              Notes
-======== ============= ======================== =====
-12.8     >=570.26      ``570.195.03``           R570 branch or newer
-11.8     >=520.61.05   ``535.288.01``           R535 branch or newer
-======== ============= ======================== =====
+=============== ====== ================ ========================== ===============================================
+Build           RAPIDS CUDA Toolkit     Recommended Min Driver     Verified On
+=============== ====== ================ ========================== ===============================================
+cuda.version=12 26.02  12.9.1           R575+ (575.51.03+)         driver 575.57.08, driver 580.126.20
+cuda.version=13 26.02  13.1.0           R590+ (590.44.01+)         driver 590.48.01
+=============== ====== ================ ========================== ===============================================
 
-The chart default is ``cuda.version: "12.8"``. To use CUDA 11.8, add ``--set cuda.version="11.8"`` to your Graphistry helm install command.
+Older drivers may work via NVIDIA's `forward compatibility <https://docs.nvidia.com/deploy/cuda-compatibility/>`_ layer but are not verified by Graphistry. See the `RAPIDS Platform Support <https://docs.rapids.ai/platform-support/>`_ matrix and `CUDA Toolkit Release Notes <https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/>`_ for full details.
+
+The chart default is ``cuda.version: "12"``. To use CUDA 13 (requires driver R590+), add ``--set cuda.version="13"`` to your Graphistry helm install command.
 
 Wait for the operator pods to be ready:
 

--- a/docs/source/graphistry-helm-docs.rst
+++ b/docs/source/graphistry-helm-docs.rst
@@ -93,7 +93,7 @@ There are some deployment-specific values which must be set, such as **global.pr
 
         global:
             provisioner: <your-csi-provisioner>
-            tag: v2.45.11
+            tag: v2.50.0
             storageClassNameOverride: ""
             nodeSelector:
               nvidia.com/gpu.present: "true"
@@ -440,7 +440,7 @@ The following table lists the configurable parameters of the Graphistry-helm-cha
 
    * - ``cuda.version``                                  
      - cuda version                                                                                        
-     - ``"12.8"``                                        
+     - ``"12"``                                        
 
 
 
@@ -686,7 +686,7 @@ The following table lists the configurable parameters of the Graphistry-helm-cha
 
    * - ``global.tag``                                    
      -                                                                                                     
-     - ``"v2.45.11"``                                    
+     - ``"v2.50.0"``                                    
 
 
 

--- a/docs/source/values-override.rst
+++ b/docs/source/values-override.rst
@@ -48,7 +48,7 @@ Below is an example ``values.yaml`` for a single-node deployment:
       nodeSelector:
         nvidia.com/gpu.present: "true"
 
-      tag: v2.45.11
+      tag: v2.50.0
       imagePullPolicy: Always
       imagePullSecrets:
         - name: docker-secret-prod
@@ -83,7 +83,7 @@ The following values must be set for a working deployment:
 * **global.imagePullSecrets** -- Docker registry credentials for pulling Graphistry images
 * **global.provisioner** -- CSI storage provisioner for your platform (e.g., ``rancher.io/local-path``, ``pd.csi.storage.gke.io``)
 * **global.nodeSelector** -- Label selector to schedule pods on GPU nodes
-* **global.tag** -- Graphistry version tag (e.g., ``v2.45.11``)
+* **global.tag** -- Graphistry version tag (e.g., ``v2.50.0``)
 
 Optional but Recommended
 -------------------------


### PR DESCRIPTION
Update driver compatibility tables, example values, and docs across all platform guides (k3s, GKE, Tanzu), troubleshooting, and Sphinx docs to reflect RAPIDS 26.02 with CUDA 12 (R575+) and CUDA 13 (R590+) support. Drop CUDA 11. Improve k3s KUBECONFIG setup, GPU verification, helm repo idempotency, and stale PV claimRef troubleshooting.