### PR TITLE
feat(v0.4.3): deployment tiers, dependency alignment, modular chart architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,8 +136,6 @@ charts/eks-dev-values.yaml
 *.lock
 charts/*/Chart.lock
 
-charts/graphistry-helm/templates/_helpers.tpl
-
 *.tgz
 
 terraform/aws/.terraform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,44 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Development]
 *   Working on fixing the Top level persistence for jupyter Notebooks, currently it is persistent inside the different directories but top level resets on redeployment.
 
+## [Version 0.4.3 - 2026-04-03]
+
+### Added
+
+- Deployment tiers: New `global.tier` value (`platform | analytics | viz | full`) controls which services are deployed. Each tier includes all capabilities of the previous tiers. Platform deploys only nexus + postgres (auth foundation for Louie or other integrations). Analytics adds GPU compute (fep, dask, redis, nginx, caddy). Viz adds graph visualization (streamgl). Full adds dashboards, notebooks, and investigation tools (gak, notebook, pivot). Default is `full` (backward compatible). Implemented via `_helpers.tpl` tier helper functions and conditional wrappers on all 21 service/PVC templates.
+- NOTES.txt: Complete rewrite. Tier-aware output showing deployed services, CUDA driver info, telemetry endpoints, PVC status, redeployment commands with volumeName preservation, and prerequisites (postgres-cluster, Docker Hub secret, StorageClass).
+- Deployment Tiers documentation: Added to all platform READMEs (k3s, GKE, Tanzu) with tier descriptions, services per tier table, PVCs per tier table, and tiers/telemetry relationship.
+- `GRAPHISTRY_CLIENT_PROTOCOL_HOSTNAME` env var: Added to base values.yaml (commented out) and k3s example values. Required for notebook iframe rendering to resolve correctly in k8s (browser needs external URL, not internal service name).
+- `volumeName.uploadsFiles`: Added to values.yaml and uploads-files PVC template. Previously missing, meaning uploads-files PVC could not rebind to existing PVs on redeployment (data loss risk). Now consistent with the other 4 PVCs.
+- Notebook persistence note: Added to all platform READMEs and configure-storageclass.rst. Only files saved under `/home/graphistry/notebooks/` persist across redeployments; demo notebooks at `/home/graphistry/demos/` reset when the image tag changes.
+- k3s `--data-dir` flag: Documented in k3s README install command. Graphistry images are large (~14GB each) and can fill the root disk; operators can point k3s storage to a separate disk.
+- README.md: Complete rewrite with repository structure, quick start links, deployment tiers overview, install commands, CUDA/driver support table, and documentation links. Preserved Azure ACR sections.
+
+### Changed
+
+- Service dependencies aligned with docker compose release.yml:
+  - dask-scheduler: removed nexus init wait (no depends_on in compose)
+  - dask-cuda-worker: changed nexus wait to dask-scheduler (matches compose)
+  - streamgl-gpu: removed nexus init wait (no depends_on in compose, gpu-router only imports config schema)
+  - pivot: removed nexus wait, kept postgres only (matches compose)
+  - forge-etl-python: added missing dask-cuda-worker and redis waits (matches compose)
+  - streamgl-viz: removed postgres and redis waits (no depends_on in compose)
+  - nginx: removed all service waits (compose has no depends_on, nginx returns 502 if upstream not ready)
+- Static file sharing: streamgl-viz and pivot copy static files to data-mount PVC subpaths (static/viz-build, static/pivot-www). Nginx reads from PVC subpaths instead of emptyDir volumes. Eliminates two heavy init containers that pulled full streamgl-viz (~14GB) and pivot images just to copy frontend files.
+- dask-cuda-worker liveness `failureThreshold`: 1 -> 3, matching all other services. Threshold of 1 caused unnecessary restarts during startup race when forge-etl-python was not ready yet.
+- PV claimRef patch instructions: Updated across all READMEs, troubleshooting, and configure-storageclass.rst to include `kubectl get pv --watch | grep Released` step. PVs take up to 60 seconds to transition from Bound to Released after helm uninstall; running the patch too early produces no output.
+- Default image tag: v2.50.0 -> v2.50.1 in base values.yaml, all example values, all READMEs, and Sphinx docs.
+- Driver verification tables: Added R595 (595.58.03) to verified drivers for both CUDA 12 and CUDA 13 across all platform READMEs and troubleshooting guide.
+- Helm repo add: Added `--force-update` flag in k3s README (idempotent, no error if repo already exists).
+- Charts version: graphistry-helm 0.4.2 -> 0.4.3.
+- Platform READMEs (k3s, GKE, Tanzu): Added Deployment Tiers section, notebook persistence note, uploadsFiles in volumeName echo commands, PV --watch instructions, k3s --data-dir flag, KUBECONFIG ~/.bashrc recommendation, GPU test wait pattern, GRAPHISTRY_CLIENT_PROTOCOL_HOSTNAME for notebook iframe rendering.
+- Troubleshooting guide: Updated PV claimRef patch with --watch, added uploadsFiles to volumeName examples, updated driver compatibility tables with R595 verification.
+- Sphinx docs (10mins-to-k8s.rst, graphistry-helm-docs.rst, values-override.rst, configure-storageclass.rst): Added full Deployment Tiers section (tier descriptions, services per tier table, PVCs per tier table, tiers and telemetry). Updated version references, added uploadsFiles to volumeName examples, added notebook persistence note, added PV --watch instructions.
+
+### Fixed
+
+- uploads-files PVC volumeName binding: Was hardcoded as a comment (`#volumeName: pvc-...`) instead of using the dynamic `volumeName.uploadsFiles` value like the other 4 PVCs. On redeployment, uploads-files PVC could not rebind to its existing PV, causing user upload data loss.
+
 ## [Version 0.4.2 - 2026-03-26]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,9 +1,98 @@
 # graphistry-helm
-Run Graphistry in Kubernetes using this live helm repository and supporting automation scripts & documentation 
 
-See [CHANGELOG.md](CHANGELOG.md) for version history. For contributing to this repository as a developer, see [DEVELOP.md](DEVELOP.md)
+Company-wide Helm charts for deploying Graphistry products on Kubernetes.
 
-## Private docker image repositories
+See [CHANGELOG.md](CHANGELOG.md) for version history. For contributing as a developer, see [DEVELOP.md](DEVELOP.md).
+
+## Repository Structure
+
+```
+graphistry-helm/
+  charts/
+    graphistry-helm/          # Graphistry product chart
+    postgres-cluster/         # Crunchy Data PGO PostgreSQL cluster
+    k8s-dashboard/            # Kubernetes dashboard (optional)
+  charts-aux-bundled/         # Bundled auxiliary charts (PGO operator, ingress-nginx, etc.)
+  chart-bundler/              # Script to fetch and bundle auxiliary charts
+  docs/                       # Sphinx documentation (ReadTheDocs)
+  charts/values-overrides/
+    examples/
+      k3s/                    # k3s deployment guide and example values
+      gke/                    # GKE deployment guide and example values
+      tanzu/                  # Tanzu/vSphere deployment guide and example values
+      cluster/                # Multi-node cluster mode values
+      troubleshooting.md      # Comprehensive troubleshooting guide (11 stages)
+```
+
+## Quick Start
+
+Each platform has a dedicated deployment guide with step-by-step instructions:
+
+- [k3s Deployment Guide](charts/values-overrides/examples/k3s/README.md)
+- [GKE Deployment Guide](charts/values-overrides/examples/gke/README.md)
+- [Tanzu/vSphere Deployment Guide](charts/values-overrides/examples/tanzu/README.md)
+- [Troubleshooting Guide](charts/values-overrides/examples/troubleshooting.md)
+
+## Prerequisites
+
+1. **Kubernetes cluster** with GPU nodes (k3s, GKE, Tanzu, EKS, AKS)
+2. **NVIDIA GPU Operator** or device plugin installed on GPU nodes
+3. **Helm 3+**
+4. **Docker Hub access** to Graphistry images (contact [Graphistry Support](https://www.graphistry.com/support))
+
+## Deployment Tiers
+
+Graphistry v2.50.1+ supports four deployment tiers via `global.tier` in your values file:
+
+| Tier | Description | GPU Required |
+|------|-------------|:------------:|
+| `platform` | `postgres` + `nexus`. Auth provider, foundation for Louie or other integrations. | No |
+| `analytics` | `platform` + GPU compute, ETL processing, GFQL graph queries, public API access. | Yes |
+| `viz` | `analytics` + interactive graph visualization with WebGL rendering and real-time GPU layout. | Yes |
+| `full` | `viz` + Streamlit dashboards, Jupyter notebooks, and investigation tools. **Default tier**. | Yes |
+
+Each tier includes all capabilities of the previous tiers. See the platform deployment guides for the full services and PVCs per tier tables.
+
+## Install
+
+```bash
+# 1. Bundle auxiliary charts (PGO operator, ingress-nginx, etc.)
+bash chart-bundler/bundler.sh
+
+# 2. Create namespace and Docker Hub secret
+kubectl create namespace graphistry
+kubectl create secret docker-registry docker-secret-prod \
+    --namespace graphistry \
+    --docker-server=docker.io \
+    --docker-username=<DOCKERHUB_USER> \
+    --docker-password=<DOCKERHUB_TOKEN>
+
+# 3. Install PGO operator
+helm install pgo ./charts-aux-bundled/pgo -n postgres-operator --create-namespace
+
+# 4. Install PostgreSQL cluster
+helm install pg-cluster ./charts/postgres-cluster -n graphistry
+
+# 5. Install Graphistry
+helm install g-chart ./charts/graphistry-helm \
+    --values ./charts/values-overrides/examples/<platform>/<platform>_example_values.yaml \
+    --namespace graphistry
+```
+
+Replace `<platform>` with `k3s`, `gke`, or `tanzu`. See the platform-specific README for StorageClass setup, GPU operator installation, and other prerequisites.
+
+## CUDA and Driver Support
+
+Graphistry v2.50.1+ uses RAPIDS 26.02 and publishes two image flavors:
+
+| Build | RAPIDS | CUDA Toolkit | Recommended Min Driver |
+|-------|--------|-------------|----------------------|
+| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) |
+| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) |
+
+See the [RAPIDS Platform Support](https://docs.rapids.ai/platform-support/) matrix and [NVIDIA CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/) for the full driver compatibility matrix.
+
+## Private Docker Image Repositories
 
 We recommend using a private repository to avoid rate-limiting and improve security:
 
@@ -30,65 +119,52 @@ Updates:
 * Login to Azure: `az login`
 * Run:
 ```bash
-APP_BUILD_TAG=latest ACR_NAME=myacr DOCKERHUB_USERNAME=mydockerhubuser DOCKERHUB_TOKEN=mydockerhubtoken ./acr-bootstrap/import-image-into-acr-from-dockerhub.sh 
+APP_BUILD_TAG=latest ACR_NAME=myacr DOCKERHUB_USERNAME=mydockerhubuser DOCKERHUB_TOKEN=mydockerhubtoken ./acr-bootstrap/import-image-into-acr-from-dockerhub.sh
 ```
 
-## Kubernetes secrets
+### Azure Kubernetes Secrets
 
-### Azure
-
-Create a Azure Container Registry Container principal ID by running the following command with your ACR information to create a kube secret with the ACR principal ID(This script assumes a default namespace, to change, edit the script):
+Create an Azure Container Registry principal ID by running the following command with your ACR information:
 
     ACR_NAME=myacr AZSUBSCRIPTION="my subscription name" SERVICE_PRINCIPAL_NAME=acrk8sprincipal CONTAINER_REGISTRY_NAME=myacrk8sregistry ./acr-bootstrap/make_acr_principal_and_create_secret.sh
 
-### Any other Kubernetes cluster (assumes a default namespace)
+### Azure: Setting the Node Selector and ACR Registry
 
-    kubectl create secret docker-registry acr-secret \
-    --namespace default \
+> **Note:** Be sure to change the azurecontainerregistry value in values.yaml to the name of your ACR as well as setting the nodeSelector value to your preferred node to deploy the cluster onto.
+
+```bash
+kubectl get nodes
+```
+
+Once you have a node selected, run the following command and find the hostname of the node to use with the nodeSelector value:
+
+```bash
+kubectl describe node <node name>
+```
+
+Then set the nodeSelector value to the hostname of the selected node along with your ACR container registry name:
+
+```bash
+helm upgrade -i my-graphistry-chart graphistry-helm/Graphistry-Helm-Chart \
+    --set azurecontainerregistry.name=<container-registry-name>.azurecr.io \
+    --set nodeSelector."kubernetes\\.io/hostname"=<node hostname> \
+    --set domain=<FQDN or node external IP ex: example.com> \
+    --set imagePullSecrets=<secrets_name>
+```
+
+> **Note:** Different labels can be used for the nodeSelector value, but some labels between the nodes may not be unique.
+
+### Any Other Kubernetes Cluster
+
+    kubectl create secret docker-registry docker-secret-prod \
+    --namespace graphistry \
     --docker-server=<CONTAINER_REGISTRY_NAME>.azurecr.io \
     --docker-username=<Docker username> \
-    --docker-password=<Docker password> 
+    --docker-password=<Docker password>
 
-## Add gpu daemonset to cluster
-> **Note:** Be sure to add the nvidia device plugin daemonset to the cluster before deployment. \
-```kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/master/nvidia-device-plugin.yml```
+## Documentation
 
-once daemonset has been installed and started
-if successful will see nvidia.com/gpu in nodes capacity here \
-```kubectl get nodes -ojson | jq .items[].status.capacity```
-
-## install Nginx ingress controller
-> **Note:** Be sure to add the nginx ingress controller to the cluster before deployment. \
-```helm upgrade --install ingress-nginx ingress-nginx --repo https://kubernetes.github.io/ingress-nginx --namespace ingress-nginx --create-namespace```
-
-## install Longhorn NFS
-> **Note:** Be sure to add Longhorn  to the cluster before deployment. \
-```helm repo add longhorn https://charts.longhorn.io ``` \
-```helm repo update``` \
-```kubectl create namespace longhorn-system``` \ 
-```kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/prerequisite/longhorn-iscsi-installation.yaml -n longhorn-system``` \
-```helm upgrade -i longhorn longhorn/longhorn --namespace longhorn-system ```
-
-
-## Setting the node selector and the acr container registry for deployment 
-> **Note:** Be sure to change the azurecontainerregistry value in values.yaml to the name of your acr as well as setting the nodeSelector value to your preferred node to deploy the cluster onto.
-    
-```kubectl get nodes```
-
-once you have a node selected, run the following command and find the hostname of the node to use with the nodeSelector value:
-
-```kubectl describe node <node name>```
-
-and then set the nodeSelector value to the hostname of the selected node along with your acr container registry name.:
-
-
-    helm upgrade -i my-graphistry-chart graphistry-helm/Graphistry-Helm-Chart \
-     --set azurecontainerregistry.name=<container-registry-name>.azurecr.io \
-     --set nodeSelector."kubernetes\\.io/hostname"=<node hostname> \ 
-     --set domain = <FQDN or node external IP ex: example.com> \
-     --set imagePullSecrets=<secrets_name>  (has to go last) 
-> **Note:** different labels can be used for the nodeSelector value, but some labels between the nodes may not be unique.
-
-
-[ReadTheDocs](https://graphistry-helm.readthedocs.io/)
-
+- [ReadTheDocs](https://graphistry-helm.readthedocs.io/) (Sphinx docs)
+- [Troubleshooting Guide](charts/values-overrides/examples/troubleshooting.md) (11 deployment stages, verified commands, sample outputs)
+- [StorageClass Configuration](docs/source/configure-storageclass.rst)
+- [Telemetry Guide](https://graphistry-admin-docs.readthedocs.io/en/latest/telemetry/kubernetes.html)

--- a/charts/graphistry-helm/Chart.yaml
+++ b/charts/graphistry-helm/Chart.yaml
@@ -1,5 +1,5 @@
 name: Graphistry-Helm-Chart
-version: 0.4.2
+version: 0.4.3
 apiVersion: v1
 description: >
  Helm Charts to deploy Graphistry to kubernetes for 100x visualizations
@@ -91,7 +91,7 @@ long_description: |
 
           global:
               provisioner: <your-csi-provisioner>
-              tag: v2.50.0
+              tag: v2.50.1
               storageClassNameOverride: ""
               nodeSelector:
                 nvidia.com/gpu.present: "true"

--- a/charts/graphistry-helm/charts/telemetry/values.yaml
+++ b/charts/graphistry-helm/charts/telemetry/values.yaml
@@ -39,7 +39,7 @@ global:  ## global settings for all charts
   # Telemetry documentation:
   # https://github.com/graphistry/graphistry-cli/blob/master/docs/tools/telemetry.md#kubernetes-deployment
   telemetryStack:
-    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials bellow
+    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials below
     openTelemetryCollector:
       image: "otel/opentelemetry-collector-contrib:0.87.0"
       # Settings for cloud mode (when OTEL_CLOUD_MODE: true)

--- a/charts/graphistry-helm/templates/NOTES.txt
+++ b/charts/graphistry-helm/templates/NOTES.txt
@@ -1,5 +1,3 @@
-
-
 "============================================================================="
 "                                                                             "
 " ______  ______ _______  _____  _     _ _____ _______ _______  ______ __   __"
@@ -9,260 +7,176 @@
 "                                                                             "
 "============================================================================="
 
-
 Thank you for installing {{ .Chart.Name }}.
 
-Your release is named {{ .Release.Name }}.
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Version: {{ .Values.global.tag }}
+CUDA: {{ .Values.cuda.version }}
+Tier: {{ .Values.global.tier | default "full" }}
 
-To learn more about the release, try:
+{{- if eq .Values.global.devMode false }}
 
+PREREQUISITES (must be installed before Graphistry):
+  1. Postgres cluster:  helm install pg-cluster ./charts/postgres-cluster -n {{ .Release.Namespace }}
+  2. Docker Hub secret:  kubectl create secret docker-registry docker-secret-prod \
+       --namespace {{ .Release.Namespace }} --docker-server=docker.io \
+       --docker-username=<USER> --docker-password=<TOKEN>
+  3. StorageClass:       kubectl apply -f retain-sc.yaml (reclaimPolicy: Retain)
+
+  If nexus stays in Init or ImagePullBackOff, check these first.
+
+DEPLOYED SERVICES:
+{{- if eq (include "graphistry.tier.platform" .) "true" }}
+  [platform] nexus (auth, dashboard, API)
+{{- end }}
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
+  [analytics] forge-etl-python, dask-scheduler, dask-cuda-worker, redis, nginx, caddy
+{{- end }}
+{{- if eq (include "graphistry.tier.viz" .) "true" }}
+  [viz] streamgl-gpu, streamgl-viz, streamgl-sessions
+{{- end }}
+{{- if eq (include "graphistry.tier.full" .) "true" }}
+  [full] graph-app-kit-public, graph-app-kit-private, notebook, pivot
+{{- end }}
+
+TIER:
+  Current: {{ .Values.global.tier | default "full" }}
+  Set via global.tier in your values file. To change tiers, update the value and
+  follow the redeployment steps below.
+
+  Available tiers (each includes all capabilities of the previous):
+    platform  -> nexus + postgres (minimum tier, auth provider, foundation for Louie or other integrations)
+    analytics -> platform + fep + dask + redis + nginx + caddy (GPU compute, ETL, GFQL, API)
+    viz       -> analytics + streamgl (interactive graph visualization, WebGL, real-time layout)
+    full      -> viz + gak + notebook + pivot (dashboards, Jupyter, all tools)
+
+{{- if eq .Values.global.tier "platform" }}
+
+  Note: platform is the minimum tier, intended as a foundation for other products
+  (e.g., Louie). Services in the same namespace connect to nexus internally via
+  http://nexus:8000. For external access, use port-forward or create an Ingress:
+  $ kubectl port-forward -n {{ .Release.Namespace }} svc/nexus 8000:8000
+{{- end }}
+
+VERIFY DEPLOYMENT:
   $ helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
   $ helm get all {{ .Release.Name }} -n {{ .Release.Namespace }}
+  $ kubectl get pods -n {{ .Release.Namespace }}
+  $ kubectl get pvc -n {{ .Release.Namespace }}
 
-{{ if eq .Values.global.devMode false }} 
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
 
-HOW TO:
-
-
-
-RESTART POLICY
-
-restartPolicy - is set to: {{ .Values.restartPolicy }}
-
-To change the restartPolicy while deployed: 
-
-
-HOW TO:
-helm upgrade -i {{ .Release.Name }} --set restartPolicy=Never graphistry-helm/Graphistry-Helm-Chart  -n {{ .Release.Namespace }}
-
-
-
-VERSION
-
-tag - release being deployed is:  {{ .Values.tag }}
-
-To change the tag while deployed set tag to another version that is in your Azure container registry by setting the proper version: 
-
-
-HOW TO:
-
-helm upgrade -i {{ .Release.Name }} --set tag=v2.38.10 graphistry-helm/Graphistry-Helm-Chart -n {{ .Release.Namespace }}
-
-LOAD BALANCER
- 
- INGRESS MANAGEMENT ANNOTATIONS - default is set to: {{ .Values.ingress.management.annotations }} can be configured for each major cloud service (aws, azure, gcp)
-in the values.yaml file:
-ingress:
-  management:
-    annotations:
-      #service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-      #cloud.google.com/load-balancer-type: "Internal"
-      #service.beta.kubernetes.io/aws-load-balancer-internal: "true"
-
- Can change while deployed : 
-
-HOW TO:
-
- helm upgrade -i {{ .Release.Name }} graphistry-helm/Graphistry-Helm-Chart -n {{ .Release.Namespace }} \
-  --set-string ingress.management.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-internal"="true" 
-
-
-NODE SELECTOR
-
-
-nodeSelector - is set to: {{ .Values.nodeSelector }}
-
-
-
-can change the nodeSelector while deployed:
-
-HOW TO:
-
-1)create a label on the preferred node 
-
-ex:
-kubectl label nodes <node_name> accelerator=nvidia (by default the nodeSelector is accelerator=nvidia)
-
-2) set the nodeSelector while deploying with the label you assigned the node:
-ex:
-
-helm upgrade -i {{ .Release.Name }} graphistry-helm/Graphistry-Helm-Chart -n {{ .Release.Namespace }} \ 
-  --set nodeSelector."accelerator"=nvidia 
-
-can change to any label provided by kubectl describe node <node_name> just follow the format provided.
-
-
-
-
-MULTI NODE - 
-
-multiNode- is set to {{ .Values.global.multiNode }}
-
-HOW TO:
-
-1)create a label on the preferred node 
-
-ex:
-kubectl label nodes <node_name> accelerator=nvidia (by default the nodeSelector is accelerator=nvidia)
-
-2) set the multiNode flag to true while deploying with the label you assigned the node along with the nodeSelector
-label you assigned.:
-
-ex:
-
-helm upgrade -i {{ .Release.Name }} graphistry-helm/Graphistry-Helm-Chart -n {{ .Release.Namespace }} \ 
-  --set multiNode=true \
-  --set nodeSelector."accelerator"=nvidia  
-
-NOTE:
-azure has a predefined nodelabel for GPUS:  --set nodeSelector."kubernetes\\.azure\\.com/accelerator"=nvidia 
-
-
-
-DEPLOYMENT STRATEGY
-
-rollingUpdate: is set to {{ .Values.rollingUpdate }}
-
-false: sets deployment strategy to Recreate
-true: sets deployment strategy to RollingUpdate
-
-HOW TO:
-
-to change deployment strategy to rollingUpdate while deployed:
-
-ex:
-
-$ helm upgrade -i {{ .Release.Name }} graphistry-helm/Graphistry-Helm-Chart -n {{ .Release.Namespace }} \
-  --set rollingUpdate=true
-
-DOMAIN
-
-domain is set to : {{ .Values.domain }}
-
-HOW TO:
-to change the domain while deployed:
-
-ex: 
-
-  $ helm upgrade -i {{ .Release.Name }} graphistry-helm/Graphistry-Helm-Chart -n {{ .Release.Namespace }} \
-    --set domain=graphistry.com but DNS has to resolve to the IP address of the node and you must own the domain.
-
-{{- if eq .Values.tls true  }}
- can use  http://nip.io  for wildcard DNS for any address 
- https://<node_IP>.nip.io
-
- to visit the deployed application:
-https://{{ .Values.domain }}
-
-{{ if eq .Values.k8sDashboard.enabled true }} 
-
-k8sDashboard - is enabled and set to: 
-readonly: {{ .Values.k8sDashboard.readonly }}
-
- to visit the deployed dashboard:
-https://{{ .Values.domain }}/k8s/dashboard/
-{{ end }}
-
-
-{{ else }}
-
- can use  http://nip.io  for wildcard DNS for any address 
- http://<node_IP>.nip.io
-
-{{ if .Values.domain }}
- to visit the deployed application:
-http://{{ .Values.domain }}
-{{ else }}
- to visit the deployed application:
-kubectl get ingress -n {{ .Release.Namespace }}
-{{ end }}
+GPU HEALTH CHECKS:
+  $ kubectl exec -n {{ .Release.Namespace }} $(kubectl get pods -n {{ .Release.Namespace }} -o name | grep forge-etl-python | head -1) -- nvidia-smi
+  $ kubectl exec -n {{ .Release.Namespace }} $(kubectl get pods -n {{ .Release.Namespace }} -o name | grep forge-etl-python | head -1) -- curl -s http://localhost:8080/cudfhealth
 {{- end }}
 
-{{ if eq .Values.global.ENABLE_CLUSTER_MODE true }}
-You are installing the Graphistry Cluster Mode deployment!
-
-1. The leader instance runs in a separate namespace (e.g., graphistry1).
-2. The leader namespace  has the primary PostgreSQL instance, while followers connect to it from other namespaces.
-3. Redis is also centrally managed by the leader's namespace for all Nexus and forge-etl-python services.
-4. When enabled, the leader namespace has the Telemetry stack for the cluster.
-5. The follower instances run in separate namespaces (e.g., graphistry2, graphistry3, etc.).
-6. The follower instances connect to the leader's namespace services, and replicate data and user actions.
-7. All instances use the same Storage Class for sharing the datasets and files (see retain-sc-cluster).
-
-{{ if eq .Values.global.IS_FOLLOWER true }}
-This deployment is set up as a follower instance and will use the leader's namespace services.
+ACCESS:
+{{- if eq .Values.tls true }}
+  Graphistry: https://{{ .Values.domain }}
+{{- else if .Values.domain }}
+  Graphistry: http://{{ .Values.domain }}
 {{- else }}
-This deployment is set up as the leader instance, the services should be accessible by the followers for proper replication and data consistency.
+  $ kubectl get ingress -n {{ .Release.Namespace }}
+{{- end }}
+{{- if eq .Values.global.ENABLE_OPEN_TELEMETRY true }}
+{{- if .Values.domain }}
+  Grafana:    {{ if eq .Values.tls true }}https{{ else }}http{{ end }}://{{ .Values.domain }}/grafana
+  Prometheus: {{ if eq .Values.tls true }}https{{ else }}http{{ end }}://{{ .Values.domain }}/prometheus
+  Jaeger:     {{ if eq .Values.tls true }}https{{ else }}http{{ end }}://{{ .Values.domain }}/jaeger
+{{- else }}
+  Telemetry endpoints available at /grafana, /prometheus, /jaeger (see kubectl get ingress -n {{ .Release.Namespace }})
+{{- end }}
 {{- end }}
 
-Next steps:
-1. Verify the deployment:
-   To check the status of your deployment:
-   $ helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
-
-2. Access the Graphistry instance:
-   Get the addresses of your instance:
-   $ kubectl get services --namespace {{ .Release.Namespace }} | grep caddy
-
-3. Monitor your resources:
-   Check the resources and status of pods:
-   $ kubectl get pods --namespace {{ .Release.Namespace }}
-
-4. Telemetry (Optional):
-   When telemetry is enabled, if telemetryStack.OTEL_CLOUD_MODE is set to true, the followers send telemetry data directly to the OTEL_EXPORTER_OTLP_ENDPOINT. Otherwise, they send it to the leader's OpenTelemetry Collector, which forwards the data to the observability tools.
-
-For more information, refer to the official Graphistry cluster deployment documentation:
-https://github.com/graphistry/graphistry-helm/tree/main/charts/values-overrides/examples/cluster
-https://graphistry-admin-docs.readthedocs.io/en/latest/telemetry/kubernetes.html
-
-Enjoy managing and scaling your Graphistry cluster!
-
+CUDA:
+  Version: {{ .Values.cuda.version }} (valid options: "12" or "13")
+{{- if eq .Values.cuda.version "12" }}
+  Base image: rapidsai/base:26.02-cuda12-py3.10 (CUDA 12.9.1 toolkit)
+  Recommended driver: R575+ (575.51.03+). Verified on R570 (forward compat), R575, R580, R590, R595.
+{{- else }}
+  Base image: rapidsai/base:26.02-cuda13-py3.10 (CUDA 13.1.0 toolkit)
+  Required driver: R590+ (590.44.01+). RAPIDS 26.02 base image bakes CUDA 13.1, not 13.0.
+  Verified on R590, R595.
 {{- end }}
+  Full driver compatibility: https://docs.rapids.ai/platform-support/
+
+TELEMETRY:
+  ENABLE_OPEN_TELEMETRY: {{ .Values.global.ENABLE_OPEN_TELEMETRY }}
+{{- if eq .Values.global.ENABLE_OPEN_TELEMETRY true }}
+  OTEL endpoint: {{ .Values.global.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  Ingress paths: /grafana, /prometheus, /jaeger
+  Docs: https://graphistry-admin-docs.readthedocs.io/en/latest/telemetry/kubernetes.html
+{{- end }}
+
+{{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
+CLUSTER MODE:
+  Leader/follower: {{ if eq .Values.global.IS_FOLLOWER true }}follower{{ else }}leader{{ end }}
+
+  1. The leader namespace has the primary PostgreSQL instance, while followers connect to it from other namespaces.
+  2. Redis is centrally managed by the leader's namespace for all Nexus and forge-etl-python services.
+  3. When enabled, the leader namespace has the Telemetry stack for the cluster.
+  4. Follower instances connect to the leader's namespace services and replicate data and user actions.
+  5. All instances use the same Storage Class for sharing datasets and files (see retain-sc-cluster).
+{{- if eq .Values.global.ENABLE_OPEN_TELEMETRY true }}
+  6. Telemetry: {{ if .Values.global.telemetryStack.OTEL_CLOUD_MODE }}followers send data directly to OTEL_EXPORTER_OTLP_ENDPOINT{{ else }}followers send data to leader's OpenTelemetry Collector{{ end }}.
+{{- end }}
+
+  See: https://github.com/graphistry/graphistry-helm/tree/main/charts/values-overrides/examples/cluster
+{{- end }}
+
+VOLUMES:
+  PVCs created for this deployment:
+{{- if eq (include "graphistry.tier.platform" .) "true" }}
+    data-mount (64Gi)        - shared data: datasets, cache, notebooks, static files
+    local-media-mount (4Gi)  - nexus static files (Django collectstatic)
+{{- end }}
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
+    uploads-files (40Gi)     - user uploaded files for ETL processing
+{{- end }}
+{{- if eq (include "graphistry.tier.full" .) "true" }}
+    gak-public (4Gi)         - Graph App Kit public dashboards
+    gak-private (4Gi)        - Graph App Kit private dashboards
+{{- end }}
+
+  Check PVC status:
+  $ kubectl get pvc -n {{ .Release.Namespace }}
+
+REDEPLOYMENT:
+  Before upgrading or reinstalling, preserve existing volume bindings:
+
+  $ echo "volumeName:
+    dataMount: $(kubectl get pvc data-mount -n {{ .Release.Namespace }} -o jsonpath='{.spec.volumeName}')
+    localMediaMount: $(kubectl get pvc local-media-mount -n {{ .Release.Namespace }} -o jsonpath='{.spec.volumeName}')
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
+    uploadsFiles: $(kubectl get pvc uploads-files -n {{ .Release.Namespace }} -o jsonpath='{.spec.volumeName}')
+{{- end }}
+{{- if eq (include "graphistry.tier.full" .) "true" }}
+    gakPublic: $(kubectl get pvc gak-public -n {{ .Release.Namespace }} -o jsonpath='{.spec.volumeName}')
+    gakPrivate: $(kubectl get pvc gak-private -n {{ .Release.Namespace }} -o jsonpath='{.spec.volumeName}')
+{{- end -}}
+  "
+
+  Copy the output into your values file, then run helm upgrade.
+
+  If pods stay Pending after reinstall (stale PV claimRef):
+  $ kubectl get pv -o json | \
+      jq -r '.items[] | select(.status.phase=="Released") | select(.spec.claimRef.namespace=="{{ .Release.Namespace }}") | .metadata.name' | \
+      xargs -I {} kubectl patch pv {} -p '{"spec":{"claimRef": null}}'
+
+TROUBLESHOOTING:
+  https://github.com/graphistry/graphistry-helm/blob/main/charts/values-overrides/examples/troubleshooting.md
 
 {{ else }}
 
-*** DEV MODE IS {{.Values.global.devMode }} ***
-  
-The cluster is currently running in Developers Mode with only a small number of containers running.
+*** DEV MODE ***
 
-postgres, nexus, nginx, are all running in Developers Mode
+  tag: {{ .Values.global.tag }}
 
-HOW TO:
-
-When in developer mode set the Tag in the values.yaml file to the latest version of the developers containers.
-
-Tag: is set to {{ .Values.tag }} for this deployment of development containers.
-
-to set the tag to the latest version of the developers containers while deployed:
-$ helm upgrade -i {{ .Release.Name }} ./charts/graphistry-helm -n {{ .Release.Namespace }} \
-  --set tag={{ .Values.tag }} \ 
-  --values ./charts/graphistry-helm/skinny-values.yaml
-
-
-HOW TO:
-
-check logs: 
-
-1) to get the name of the pod: 
-$ kubectl get pods -n {{ .Release.Namespace }} 
-
-
-2) THEN:
-$ kubectl logs -n graphistry <pod name> -f
-
-HOW TO:
-
-shell into the pod:
-
-1) to get the name of the pod:
-$ kubectl get pods -n {{ .Release.Namespace }} 
-
-2) to get shell in the pod:
-$ kubectl exec -it -n {{ .Release.Namespace }} <pod name> -- /bin/bash
-
-
+  Useful commands:
+  $ kubectl get pods -n {{ .Release.Namespace }}
+  $ kubectl logs -n {{ .Release.Namespace }} <pod-name> -f
+  $ kubectl exec -it -n {{ .Release.Namespace }} <pod-name> -- /bin/bash
 
 {{- end }}
-
-
-

--- a/charts/graphistry-helm/templates/_helpers.tpl
+++ b/charts/graphistry-helm/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{/*
+Deployment tier helpers.
+
+Tier ordering: platform (1) < analytics (2) < viz (3) < full (4)
+Each tier includes all capabilities of the previous tiers.
+*/}}
+
+{{- define "graphistry.tierLevel" -}}
+  {{- $tier := .Values.global.tier | default "full" -}}
+  {{- if not (has $tier (list "platform" "analytics" "viz" "full")) -}}
+    {{- fail (printf "Invalid global.tier: %s. Must be one of: platform, analytics, viz, full" $tier) -}}
+  {{- end -}}
+  {{- if eq $tier "platform" -}}1
+  {{- else if eq $tier "analytics" -}}2
+  {{- else if eq $tier "viz" -}}3
+  {{- else -}}4
+  {{- end -}}
+{{- end -}}
+
+{{/* Returns "true" if the tier >= platform (always true) */}}
+{{- define "graphistry.tier.platform" -}}true{{- end -}}
+
+{{/* Returns "true" if the tier >= analytics */}}
+{{- define "graphistry.tier.analytics" -}}
+  {{- if ge (include "graphistry.tierLevel" . | int) 2 -}}true{{- end -}}
+{{- end -}}
+
+{{/* Returns "true" if the tier >= viz */}}
+{{- define "graphistry.tier.viz" -}}
+  {{- if ge (include "graphistry.tierLevel" . | int) 3 -}}true{{- end -}}
+{{- end -}}
+
+{{/* Returns "true" if the tier >= full */}}
+{{- define "graphistry.tier.full" -}}
+  {{- if ge (include "graphistry.tierLevel" . | int) 4 -}}true{{- end -}}
+{{- end -}}

--- a/charts/graphistry-helm/templates/caddy/caddy-cfg.yml
+++ b/charts/graphistry-helm/templates/caddy/caddy-cfg.yml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,3 +17,4 @@ data:
                   trusted_proxies private_ranges
           }
     }
+{{- end }}

--- a/charts/graphistry-helm/templates/caddy/caddy-deployment.yaml
+++ b/charts/graphistry-helm/templates/caddy/caddy-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
 {{ if eq .Values.global.devMode false }}
 apiVersion: apps/v1
 kind: Deployment
@@ -128,4 +129,5 @@ spec:
     io.kompose.service: caddy-{{ .Release.Namespace }}
 
 
+{{- end }}
 {{- end }}

--- a/charts/graphistry-helm/templates/dask/dask-cluster.yml
+++ b/charts/graphistry-helm/templates/dask/dask-cluster.yml
@@ -1,4 +1,5 @@
-{{ if eq .Values.dask.operator true }} 
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
+{{ if eq .Values.dask.operator true }}
 {{ if eq .Values.global.devMode false }}
 apiVersion: kubernetes.dask.org/v1
 kind: DaskCluster
@@ -231,5 +232,6 @@ spec:
         targetPort: "http-dashboard"
 
 
-{{ end }}     
-{{ end }}    
+{{ end }}
+{{ end }}
+{{- end }}

--- a/charts/graphistry-helm/templates/dask/dask-cluster.yml
+++ b/charts/graphistry-helm/templates/dask/dask-cluster.yml
@@ -81,7 +81,7 @@ spec:
                 - -c
                 - "curl -Lf http://localhost:8787/health && curl -f http://forge-etl-python:8080/workerhealth"
 
-            failureThreshold: 1
+            failureThreshold: 3
             initialDelaySeconds: 180
             periodSeconds: 120
             timeoutSeconds: 30

--- a/charts/graphistry-helm/templates/dask/dask-cuda-worker-daemonset.yaml
+++ b/charts/graphistry-helm/templates/dask/dask-cuda-worker-daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
 {{ if eq .Values.dask.operator false }}
 {{ if eq .Values.global.devMode false }}
 apiVersion: apps/v1
@@ -173,5 +174,6 @@ spec:
 status:
   loadBalancer: {}
 
-{{ end }}  
 {{ end }}
+{{ end }}
+{{- end }}

--- a/charts/graphistry-helm/templates/dask/dask-cuda-worker-daemonset.yaml
+++ b/charts/graphistry-helm/templates/dask/dask-cuda-worker-daemonset.yaml
@@ -36,9 +36,9 @@ spec:
         resources:
             {{- toYaml .Values.InitContainerResources | nindent 10 }}
         imagePullPolicy: {{.Values.global.imagePullPolicy }} 
-        args: 
+        args:
         - "service"
-        - "nexus"
+        - "dask-scheduler"
       containers:
         - args:
             - dask cuda worker
@@ -119,7 +119,7 @@ spec:
                 - -c
                 - "curl -Lf http://localhost:8787/health && curl -f http://forge-etl-python:8080/workerhealth"
 
-            failureThreshold: 1
+            failureThreshold: 3
             initialDelaySeconds: 180
             periodSeconds: 120
             timeoutSeconds: 30

--- a/charts/graphistry-helm/templates/dask/dask-scheduler-deployment.yaml
+++ b/charts/graphistry-helm/templates/dask/dask-scheduler-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
 {{ if eq .Values.dask.operator false }}
 {{ if eq .Values.global.devMode false }}
 apiVersion: apps/v1
@@ -134,5 +135,6 @@ spec:
     io.kompose.service: dask-scheduler
 status:
   loadBalancer: {}
-{{ end }} 
-{{ end }}  
+{{ end }}
+{{ end }}
+{{- end }}

--- a/charts/graphistry-helm/templates/dask/dask-scheduler-deployment.yaml
+++ b/charts/graphistry-helm/templates/dask/dask-scheduler-deployment.yaml
@@ -26,19 +26,6 @@ spec:
         io.kompose.network/grph: "true"
         io.kompose.service: dask-scheduler
     spec:
-      initContainers:
-      - name: "{{ lower .Chart.Name }}-init"
-        {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
-        image: "groundnuty/k8s-wait-for:latest" #DockerHub
-        {{ else }}
-        image: {{.Values.global.containerregistry.name}}/k8s-wait-for:latest
-        {{- end }}
-        resources:
-            {{- toYaml .Values.InitContainerResources | nindent 10 }}
-        imagePullPolicy: {{.Values.global.imagePullPolicy }} 
-        args: 
-        - "service"
-        - "nexus"
       containers:
         - args:
             - dask-scheduler

--- a/charts/graphistry-helm/templates/forge-etl/forge-etl-python-daemonset.yaml
+++ b/charts/graphistry-helm/templates/forge-etl/forge-etl-python-daemonset.yaml
@@ -60,7 +60,7 @@ spec:
               echo "Waiting for Redis to be online..."
               sleep 5
             done
-            echo "Redis is online! ({{ .Values.global.REDIS_URL }})"
+            echo "Redis is online!"
       {{ else }}
         {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
         image: "groundnuty/k8s-wait-for:latest" #DockerHub

--- a/charts/graphistry-helm/templates/forge-etl/forge-etl-python-daemonset.yaml
+++ b/charts/graphistry-helm/templates/forge-etl/forge-etl-python-daemonset.yaml
@@ -27,9 +27,50 @@ spec:
         image: {{.Values.global.containerregistry.name}}/k8s-wait-for:latest
         {{- end }}
         imagePullPolicy: {{.Values.global.imagePullPolicy }} 
-        args: 
+        args:
         - "service"
         - "dask-scheduler"
+        resources:
+            {{- toYaml .Values.InitContainerResources | nindent 10 }}
+      - name: "forge-etl-python-wait-for-dask-cuda-worker"
+        {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
+        image: "groundnuty/k8s-wait-for:latest" #DockerHub
+        {{ else }}
+        image: {{.Values.global.containerregistry.name}}/k8s-wait-for:latest
+        {{- end }}
+        imagePullPolicy: {{.Values.global.imagePullPolicy }}
+        args:
+        - "service"
+        - "dask-cuda-worker"
+        resources:
+            {{- toYaml .Values.InitContainerResources | nindent 10 }}
+      - name: "forge-etl-python-wait-for-redis"
+      {{ if eq .Values.global.IS_FOLLOWER true }}
+        {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
+        image: {{.Values.redis.repository}}:{{.Values.redis.tag}} #DockerHub
+        {{ else }}
+        image: {{.Values.global.containerregistry.name}}/{{.Values.redis.repository}}:{{.Values.redis.tag}}
+        {{- end }}
+        command:
+          - "sh"
+          - "-c"
+          - |
+            until redis-cli -u {{ .Values.global.REDIS_URL }} ping | grep -q PONG; do
+              echo "Waiting for Redis to be online..."
+              sleep 5
+            done
+            echo "Redis is online! ({{ .Values.global.REDIS_URL }})"
+      {{ else }}
+        {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
+        image: "groundnuty/k8s-wait-for:latest" #DockerHub
+        {{ else }}
+        image: {{.Values.global.containerregistry.name}}/k8s-wait-for:latest
+        {{- end }}
+        imagePullPolicy: {{.Values.global.imagePullPolicy }}
+        args:
+        - "service"
+        - "redis"
+      {{- end }}
         resources:
             {{- toYaml .Values.InitContainerResources | nindent 10 }}
       - name: "forge-etl-python-wait-for-postgres"

--- a/charts/graphistry-helm/templates/forge-etl/forge-etl-python-daemonset.yaml
+++ b/charts/graphistry-helm/templates/forge-etl/forge-etl-python-daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
 {{ if eq .Values.global.devMode false }}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -231,5 +232,6 @@ spec:
 status:
   loadBalancer: {}
 {{ end }}
+{{- end }}
 ---
 

--- a/charts/graphistry-helm/templates/graph-app-kit/graph-app-kit-private-deployment.yaml
+++ b/charts/graphistry-helm/templates/graph-app-kit/graph-app-kit-private-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.full" .) "true" }}
 {{- if eq .Values.global.devMode false }}
 
 
@@ -128,5 +129,6 @@ spec:
   selector:
     io.kompose.service: graph-app-kit-private
 
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/graphistry-helm/templates/graph-app-kit/graph-app-kit-public-deployment.yaml
+++ b/charts/graphistry-helm/templates/graph-app-kit/graph-app-kit-public-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.full" .) "true" }}
 {{- if eq .Values.global.devMode false }}
 
 
@@ -128,5 +129,6 @@ spec:
   selector:
     io.kompose.service: graph-app-kit-public
 
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/graphistry-helm/templates/ingress/caddy-ingress.yml
+++ b/charts/graphistry-helm/templates/ingress/caddy-ingress.yml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
 {{ if eq .Values.global.devMode false }}
 
 apiVersion: networking.k8s.io/v1
@@ -56,4 +57,5 @@ spec:
     secretName: letsencrypt-staging-{{ .Release.Namespace }}
 {{- end }}
 
+{{- end }}
 {{- end }}

--- a/charts/graphistry-helm/templates/ingress/nginx-ingress-dev.yml
+++ b/charts/graphistry-helm/templates/ingress/nginx-ingress-dev.yml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
 {{ if eq .Values.global.devMode true }}
 
 apiVersion: networking.k8s.io/v1
@@ -55,4 +56,5 @@ spec:
     secretName: letsencrypt-staging-{{ .Release.Namespace }}
 {{- end }}
 
+{{- end }}
 {{- end }}

--- a/charts/graphistry-helm/templates/nginx/nginx-deployment.yaml
+++ b/charts/graphistry-helm/templates/nginx/nginx-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -207,4 +208,4 @@ spec:
     io.kompose.service: nginx
 
 
-
+{{- end }}

--- a/charts/graphistry-helm/templates/nginx/nginx-deployment.yaml
+++ b/charts/graphistry-helm/templates/nginx/nginx-deployment.yaml
@@ -28,72 +28,6 @@ spec:
         io.kompose.network/grph: "true"
         io.kompose.service: nginx
     spec:
-      initContainers:
-      {{ if eq .Values.global.devMode false }}
-      - name: "nginx-wait-for-forge-etl-python"
-        {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
-        image: "groundnuty/k8s-wait-for:latest" #DockerHub
-        {{ else }}
-        image: {{.Values.global.containerregistry.name}}/k8s-wait-for:latest
-        {{- end }}
-        resources:
-          {{- toYaml .Values.InitContainerResources | nindent 10 }}
-        imagePullPolicy: {{.Values.global.imagePullPolicy }} 
-        args: 
-        - "service"
-        - "forge-etl-python"
-      - name: "nginx-wait-for-streamgl-gpu"
-        {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
-        image: "groundnuty/k8s-wait-for:latest" #DockerHub
-        {{ else }}
-        image: {{.Values.global.containerregistry.name}}/k8s-wait-for:latest
-        {{- end }}
-        resources:
-          {{- toYaml .Values.InitContainerResources | nindent 10 }}
-        imagePullPolicy: {{.Values.global.imagePullPolicy }} 
-        args: 
-        - "service"
-        - "streamgl-gpu"
-      - name: "nginx-wait-for-streamgl-sessions"
-        {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
-        image: "groundnuty/k8s-wait-for:latest" #DockerHub
-        {{ else }}
-        image: {{.Values.global.containerregistry.name}}/k8s-wait-for:latest
-        {{- end }}
-        resources:
-          {{- toYaml .Values.InitContainerResources | nindent 10 }}
-        imagePullPolicy: {{.Values.global.imagePullPolicy }} 
-        args: 
-        - "service"
-        - "streamgl-sessions"
-      - name: nginx-init-streamgl-viz
-        resources:
-          {{- toYaml .Values.InitContainerResources | nindent 10 }}
-        image: {{.Values.global.containerregistry.name}}/{{.Values.graphistry}}:{{.Values.streamglviz.repository}}-{{.Values.global.tag}}-{{.Values.cuda.version}}
-        command: 
-        - sh 
-        - -c 
-        - cp -r /opt/graphistry/apps/core/viz/build/* /tmp/build/
-        volumeMounts:
-        - name: viz-static
-          mountPath: /tmp/build
-      {{ end }}          
-      - name: nginx-init-pivot
-        {{ if eq .Values.global.devMode false }}
-        image: {{.Values.global.containerregistry.name}}/{{.Values.graphistry}}:{{.Values.pivot.repository}}-{{.Values.global.tag}}-{{.Values.cuda.version}}
-      {{ else }}
-        image: {{.Values.graphistry}}/{{.Values.pivotDev.repository}}:{{.Values.global.tag}}-dev
-    {{ end }}  
-        resources:
-          {{- toYaml .Values.InitContainerResources | nindent 10 }}
-        command: 
-        - sh 
-        - -c
-        - cp -r /opt/graphistry/apps/core/pivot/www/* /tmp/www/
-        volumeMounts:
-        - name: pivot-static
-          mountPath: /tmp/www
-          
       containers:
         - env:
           - name: ENABLE_CLUSTER_MODE
@@ -176,10 +110,12 @@ spec:
               name: viz-empty
         {{ else }}
             - mountPath: /opt/graphistry/apps/core/viz/build
-              name: viz-static
+              name: data-mount
+              subPath: static/viz-build
         {{- end }}
             - mountPath: /opt/graphistry/apps/core/pivot/www
-              name: pivot-static
+              name: data-mount
+              subPath: static/pivot-www
             - mountPath: /opt/graphistry/apps/core/nexus/staticfiles
               name: local-media-mount
             - mountPath: /opt/graphistry/data/uploads
@@ -214,12 +150,7 @@ spec:
         {{ if eq .Values.global.devMode true }}
         - name: viz-empty
           emptyDir: {}
-        {{ else }}
-        - name: viz-static
-          emptyDir: {}
-        {{- end }}
-        - name: pivot-static
-          emptyDir: {}           
+        {{- end }}           
       {{- if eq .Values.global.ENABLE_CLUSTER_MODE true }}
         - name: local-media-mount
 {{- toYaml .Values.global.clusterVolume | nindent 10 }}

--- a/charts/graphistry-helm/templates/nginx/nginx-log-exporter-configmap.yaml
+++ b/charts/graphistry-helm/templates/nginx/nginx-log-exporter-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
 {{if eq .Values.metrics true }}
 apiVersion: v1
 kind: ConfigMap
@@ -37,4 +38,5 @@ data:
       histogram_buckets = [.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]
     }
 
+{{- end }}
 {{- end }}

--- a/charts/graphistry-helm/templates/notebook/notebook-deployment.yaml
+++ b/charts/graphistry-helm/templates/notebook/notebook-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.full" .) "true" }}
 {{ if eq .Values.global.devMode false }}
 
 apiVersion: apps/v1
@@ -155,4 +156,5 @@ spec:
 status:
   loadBalancer: {}
 
+{{- end }}
 {{- end }}

--- a/charts/graphistry-helm/templates/pivot/pivot-config-configmap.yml
+++ b/charts/graphistry-helm/templates/pivot/pivot-config-configmap.yml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.full" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,3 +9,4 @@ metadata:
 data:
   config.json: |
         {  }
+{{- end }}

--- a/charts/graphistry-helm/templates/pivot/pivot-deployment.yaml
+++ b/charts/graphistry-helm/templates/pivot/pivot-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.full" .) "true" }}
 {{ if eq .Values.global.devMode false }}
 apiVersion: apps/v1
 kind: Deployment
@@ -170,3 +171,4 @@ status:
   loadBalancer: {}
 ---
 {{ end }}
+{{- end }}

--- a/charts/graphistry-helm/templates/pivot/pivot-deployment.yaml
+++ b/charts/graphistry-helm/templates/pivot/pivot-deployment.yaml
@@ -26,6 +26,19 @@ spec:
         io.kompose.service: pivot
     spec:
       initContainers:
+      - name: "pivot-copy-static"
+        {{ if eq .Values.global.devMode false }}
+        image: {{.Values.global.containerregistry.name}}/{{.Values.graphistry}}:{{.Values.pivot.repository}}-{{.Values.global.tag}}-{{.Values.cuda.version}}
+        {{ else }}
+        image: {{.Values.graphistry}}/{{.Values.pivotDev.repository}}:{{.Values.global.tag}}-dev
+        {{- end }}
+        resources:
+          {{- toYaml .Values.InitContainerResources | nindent 10 }}
+        command: ["sh", "-c", "cp -r /opt/graphistry/apps/core/pivot/www/* /tmp/pivot-static/"]
+        volumeMounts:
+          - name: data-mount
+            mountPath: /tmp/pivot-static
+            subPath: static/pivot-www
       - name: "pivot-wait-for-postgres"
         image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.5-1
         resources:
@@ -44,18 +57,6 @@ spec:
               sleep 5;
             done;
             echo "PostgreSQL is up!";
-      - name: "pivot-wait-for-nexus"
-        {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
-        image: "groundnuty/k8s-wait-for:latest" #DockerHub
-        {{ else }}
-        image: {{.Values.global.containerregistry.name}}/k8s-wait-for:latest
-        {{- end }}
-        resources:
-          {{- toYaml .Values.InitContainerResources | nindent 10 }}
-        imagePullPolicy: {{.Values.global.imagePullPolicy }} 
-        args: 
-        - "service"
-        - "nexus"
       containers:
         - env:
           - name: ENABLE_CLUSTER_MODE

--- a/charts/graphistry-helm/templates/pvc/gak-private-persistentvolumeclaim.yaml
+++ b/charts/graphistry-helm/templates/pvc/gak-private-persistentvolumeclaim.yaml
@@ -1,5 +1,6 @@
+{{- if eq (include "graphistry.tier.full" .) "true" }}
 
-{{ if eq .Values.global.devMode false }} 
+{{ if eq .Values.global.devMode false }}
 
 {{ if eq .Values.graphAppKitPrivate true }}
 apiVersion: v1
@@ -44,4 +45,5 @@ spec:
 status: {}      
 {{- end }}
 
+{{- end }}
 {{- end }}

--- a/charts/graphistry-helm/templates/pvc/gak-public-persistentvolumeclaim.yaml
+++ b/charts/graphistry-helm/templates/pvc/gak-public-persistentvolumeclaim.yaml
@@ -1,5 +1,6 @@
+{{- if eq (include "graphistry.tier.full" .) "true" }}
 
-{{ if eq .Values.global.devMode false }} 
+{{ if eq .Values.global.devMode false }}
 
 {{ if eq .Values.graphAppKitPublic true }}
 
@@ -46,4 +47,5 @@ status: {}
 {{- end }}
 
 
+{{- end }}
 {{- end }}

--- a/charts/graphistry-helm/templates/pvc/uploads-files-persistentvolumeclaim.yaml
+++ b/charts/graphistry-helm/templates/pvc/uploads-files-persistentvolumeclaim.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
 {{- if eq .Values.global.ENABLE_CLUSTER_MODE false }}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -28,9 +29,12 @@ spec:
     - ReadWriteOnce
   storageClassName: {{ .Values.global.storageClassNameOverride | default "retain-sc" }}
 {{- end }}
-  #volumeName: pvc-8147f3f6-9b84-4974-b2bb-298a6395ad5a
+{{- if .Values.volumeName.uploadsFiles }}
+  volumeName: {{ .Values.volumeName.uploadsFiles }}
+{{- end }}
   resources:
     requests:
       storage: 40Gi
 status: {}
+{{- end }}
 {{- end }}

--- a/charts/graphistry-helm/templates/redis/redis-deployment.yaml
+++ b/charts/graphistry-helm/templates/redis/redis-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
 {{ if eq .Values.global.devMode false }}
 apiVersion: apps/v1
 kind: Deployment
@@ -121,4 +122,5 @@ spec:
     io.kompose.service: redis
 status:
   loadBalancer: {}
+{{- end }}
 {{- end }}

--- a/charts/graphistry-helm/templates/service-monitors/nginx-service-monitor.yaml
+++ b/charts/graphistry-helm/templates/service-monitors/nginx-service-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.analytics" .) "true" }}
 {{if eq .Values.metrics true }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -12,4 +13,5 @@ spec:
       app: nginx-{{ .Release.Namespace }}
   endpoints:
   - port: metrics
+{{- end }}
 {{- end }}

--- a/charts/graphistry-helm/templates/streamgl/streamgl-gpu-daemonset.yaml
+++ b/charts/graphistry-helm/templates/streamgl/streamgl-gpu-daemonset.yaml
@@ -20,19 +20,6 @@ spec:
         io.kompose.network/grph: "true"
         io.kompose.service: streamgl-gpu
     spec:
-      initContainers:
-      - name: "{{ lower .Chart.Name }}-init"
-        {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
-        image: "groundnuty/k8s-wait-for:latest" #DockerHub
-        {{ else }}
-        image: {{.Values.global.containerregistry.name}}/k8s-wait-for:latest
-        {{- end }}
-        resources:
-          {{- toYaml .Values.InitContainerResources | nindent 10 }}
-        imagePullPolicy: {{.Values.global.imagePullPolicy }} 
-        args: 
-        - "service"
-        - "nexus"
       containers:
         - env:
           - name: REDIS_URL

--- a/charts/graphistry-helm/templates/streamgl/streamgl-gpu-daemonset.yaml
+++ b/charts/graphistry-helm/templates/streamgl/streamgl-gpu-daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.viz" .) "true" }}
 {{ if eq .Values.global.devMode false }}
 
 apiVersion: apps/v1
@@ -134,4 +135,5 @@ spec:
 status:
   loadBalancer: {}
 
+{{- end }}
 {{- end }}

--- a/charts/graphistry-helm/templates/streamgl/streamgl-sessions-deployment.yaml
+++ b/charts/graphistry-helm/templates/streamgl/streamgl-sessions-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.viz" .) "true" }}
 {{ if eq .Values.global.devMode false }}
 apiVersion: apps/v1
 kind: Deployment
@@ -131,4 +132,5 @@ spec:
 status:
   loadBalancer: {}
 
+{{- end }}
 {{- end }}

--- a/charts/graphistry-helm/templates/streamgl/streamgl-viz-deployment.yaml
+++ b/charts/graphistry-helm/templates/streamgl/streamgl-viz-deployment.yaml
@@ -26,54 +26,15 @@ spec:
         io.kompose.service: streamgl-viz
     spec:
       initContainers:
-      - name: "streamgl-viz-wait-for-postgres"
-        image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.5-1
+      - name: "streamgl-viz-copy-static"
+        image: {{.Values.global.containerregistry.name}}/{{.Values.graphistry}}:{{.Values.streamglviz.repository}}-{{.Values.global.tag}}-{{.Values.cuda.version}}
         resources:
           {{- toYaml .Values.InitContainerResources | nindent 10 }}
-        command:
-          - "sh"
-          - "-c"
-          - |
-            echo "Waiting for PostgreSQL to be ready..."
-          {{ if eq .Values.global.IS_FOLLOWER true }}
-            until pg_isready -h {{ .Values.global.POSTGRES_HOST }} -p 5432; do
-          {{ else }}
-            until pg_isready -h {{ .Values.global.postgres.host }}-primary -p 5432; do
-          {{- end }}
-              echo "PostgreSQL not ready, waiting 5 seconds...";
-              sleep 5;
-            done;
-            echo "PostgreSQL is up!";
-      - name: "streamgl-viz-wait-for-redis"
-      {{ if eq .Values.global.IS_FOLLOWER true }}
-        {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
-        image: {{.Values.redis.repository}}:{{.Values.redis.tag}} #DockerHub
-        {{ else }}
-        image: {{.Values.global.containerregistry.name}}/{{.Values.redis.repository}}:{{.Values.redis.tag}}
-        {{- end }}
-        command:
-          - "sh"
-          - "-c"
-          - |
-            # Wait for Redis to be ready using the provided connection string
-            until redis-cli -u {{ .Values.global.REDIS_URL }} ping | grep -q PONG; do
-              echo "Waiting for Redis to be online..."
-              sleep 5
-            done
-            echo "Redis is online! ({{ .Values.global.REDIS_URL }})"
-      {{ else }}
-        {{- if eq .Values.global.containerregistry.name "docker.io/graphistry" }}
-        image: "groundnuty/k8s-wait-for:latest" #DockerHub
-        {{ else }}
-        image: {{.Values.global.containerregistry.name}}/k8s-wait-for:latest
-        {{- end }}
-        resources:
-          {{- toYaml .Values.InitContainerResources | nindent 10 }}
-        imagePullPolicy: {{.Values.global.imagePullPolicy }} 
-        args: 
-        - "service"
-        - "redis"
-      {{- end }}
+        command: ["sh", "-c", "cp -r /opt/graphistry/apps/core/viz/build/* /tmp/viz-static/"]
+        volumeMounts:
+          - name: data-mount
+            mountPath: /tmp/viz-static
+            subPath: static/viz-build
       containers:
         - env:
           - name: REDIS_URL

--- a/charts/graphistry-helm/templates/streamgl/streamgl-viz-deployment.yaml
+++ b/charts/graphistry-helm/templates/streamgl/streamgl-viz-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "graphistry.tier.viz" .) "true" }}
 {{ if eq .Values.global.devMode false }}
 apiVersion: apps/v1
 kind: Deployment
@@ -153,4 +154,5 @@ spec:
 status:
   loadBalancer: {}
 
-{{- end }}    
+{{- end }}
+{{- end }}

--- a/charts/graphistry-helm/values.yaml
+++ b/charts/graphistry-helm/values.yaml
@@ -13,9 +13,10 @@ graphistry: graphistry   #graphistry tag for the docker image
 #volume names
 volumeName: #volume names
   dataMount: #data-mount pvc volume name
-  localMediaMount: #local-media-mount pvc volume name 
-  gakPublic:  #gak-public pvc volume name
-  gakPrivate: ##data-mount pvc volume name
+  localMediaMount: #local-media-mount pvc volume name
+  uploadsFiles: #uploads-files pvc volume name
+  gakPublic: #gak-public pvc volume name
+  gakPrivate: #gak-private pvc volume name
 
 #the namespace of the ingress controller - this is the namespace that the ingress controller is going to be deployed to.
 ingressNamespace: ingress-nginx #the namespace of the ingress controller
@@ -384,6 +385,13 @@ ProxyBodySize: 20000m #sets the proxy body size for ingress controller and uploa
 graphistryKey: ## graphistry key for dev mode in pivot deployment
 
 global:  ## global settings for all charts
+  # Deployment tier. Each tier includes all capabilities of the previous tiers.
+  # platform  -> nexus + postgres (minimum tier, auth provider, foundation for Louie or other integrations)
+  # analytics -> platform + fep + dask + redis + nginx + caddy (GPU compute, ETL, GFQL, API)
+  # viz       -> analytics + streamgl (interactive graph visualization, WebGL, real-time layout)
+  # full      -> viz + gak + notebook + pivot (dashboards, Jupyter, all tools)
+  tier: "full"
+
   # For new K8s versions (e.g. GKE) that don't need anymore the legacy annotation kubernetes.io/ingress.class: nginx
   ingressClassName: nginx
   #storage class provisioner - Each StorageClass has a provisioner that determines what volume plugin is used for provisioning PVs.
@@ -404,7 +412,7 @@ global:  ## global settings for all charts
     user: graphistry
     port: 5432
     host: postgres
-  tag: v2.50.0
+  tag: v2.50.1
   imagePullPolicy: IfNotPresent
   restartPolicy: Always
   imagePullSecrets: []
@@ -533,6 +541,11 @@ env: #environment variables
    value: "false"
  - name: ACME_AGREE
    value: "true"
+ # URL used by the browser to reach Graphistry (e.g., for notebook iframe rendering).
+ # Set to your external domain for production (e.g., https://graphistry.example.com).
+ # For local testing without a domain, use http://localhost.
+ #- name: GRAPHISTRY_CLIENT_PROTOCOL_HOSTNAME
+ #  value: "https://graphistry.example.com"
 
 #streamlit environment variables
  # can be set like helm upgrade -i  chart_name --name release_name \

--- a/charts/values-overrides/examples/azure_example_values.yaml
+++ b/charts/values-overrides/examples/azure_example_values.yaml
@@ -20,7 +20,7 @@ graphistryResources:
 
 
 global:
-  tag: v2.50.0
+  tag: v2.50.1
   provisioner: disk.csi.azure.com
   containerregistry:
     name: 

--- a/charts/values-overrides/examples/cluster/global-common.yaml
+++ b/charts/values-overrides/examples/cluster/global-common.yaml
@@ -1,5 +1,5 @@
 global:  ## global settings for all charts
-  tag: v2.50.0
+  tag: v2.50.1
   ENABLE_CLUSTER_MODE: true
   # Telemetry: https://graphistry-admin-docs.readthedocs.io/en/latest/telemetry/kubernetes.html
   ENABLE_OPEN_TELEMETRY: true

--- a/charts/values-overrides/examples/cluster/global-common.yaml
+++ b/charts/values-overrides/examples/cluster/global-common.yaml
@@ -5,9 +5,9 @@ global:  ## global settings for all charts
   ENABLE_OPEN_TELEMETRY: true
 
   telemetryStack:
-    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials bellow
+    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials below
 
-# Log levels: INFO (default), DEBUG, TRACE (for troubleshooting)
-logs:
+  # Log levels: INFO (default), DEBUG, TRACE (for troubleshooting)
+  logs:
     LogLevel: INFO
     GraphistryLogLevel: INFO

--- a/charts/values-overrides/examples/gke/README.md
+++ b/charts/values-overrides/examples/gke/README.md
@@ -437,7 +437,9 @@ global:
 | `gak-private` | graph-app-kit-private, notebook |
 | `uploads-files` | nginx, forge-etl-python |
 
-**Note**: The Postgres Cluster also requires the same StorageClass.
+**Notes**:
+- The Postgres Cluster also requires the same StorageClass.
+- The notebook service mounts `data-mount` at `/home/graphistry/notebooks/` (subPath: `notebooks`). Only files saved under this directory persist across redeployments. The default demo notebooks at `/home/graphistry/demos/` are baked into the Docker image and reset when the image tag changes. To preserve your work, save or copy notebooks to `/home/graphistry/notebooks/`.
 
 ## Install Postgres Cluster
 
@@ -473,13 +475,65 @@ kubectl get pods --watch -n graphistry
 
 **Note**: If pods stay in `Pending` state, verify the StorageClass is correctly configured (see [Configure StorageClass](#configure-storageclass)).
 
+## Deployment Tiers
+
+Graphistry supports four deployment tiers, each building on the previous. Set `global.tier` in your values file to control which services are deployed:
+
+```yaml
+global:
+  tier: "full"   # platform | analytics | viz | full
+```
+
+Each tier includes all capabilities of the previous tiers:
+
+| Tier | Description | GPU Required |
+|------|-------------|:------------:|
+| `platform` | `postgres` + `nexus`. Auth provider, foundation for Louie or other integrations. Minimum tier, services in the same namespace connect internally via `http://nexus:8000`. For external access use port-forward (`kubectl port-forward -n graphistry svc/nexus 8000:8000`) or create an Ingress. | No |
+| `analytics` | `platform` + `caddy`, `nginx`, `redis`, `dask-scheduler`, `dask-cuda-worker`, `forge-etl-python`. Public API access, GPU compute, ETL processing and GFQL graph queries. | Yes |
+| `viz` | `analytics` + `streamgl-sessions`, `streamgl-gpu`, `streamgl-viz`. Interactive graph visualization with WebGL rendering and real-time GPU layout. | Yes |
+| `full` | `viz` + `pivot`, `notebook`, `graph-app-kit` (public/private). Investigation tools (Pivot), Jupyter notebooks and Streamlit dashboards. **Default tier**. | Yes |
+
+### Services per tier
+
+| Service | platform | analytics | viz | full |
+|---------|:--------:|:---------:|:---:|:----:|
+| `postgres` (postgres-cluster chart) | X | X | X | X |
+| `nexus` | X | X | X | X |
+| `caddy` | | X | X | X |
+| `nginx` | | X | X | X |
+| `redis` | | X | X | X |
+| `dask-scheduler` | | X | X | X |
+| `dask-cuda-worker` | | X | X | X |
+| `forge-etl-python` | | X | X | X |
+| `streamgl-sessions` | | | X | X |
+| `streamgl-gpu` | | | X | X |
+| `streamgl-viz` | | | X | X |
+| `pivot` | | | | X |
+| `notebook` | | | | X |
+| `graph-app-kit-public` | | | | X |
+| `graph-app-kit-private` | | | | X |
+
+### PVCs per tier
+
+| PVC | platform | analytics | viz | full |
+|-----|:--------:|:---------:|:---:|:----:|
+| `data-mount` (64Gi) | X | X | X | X |
+| `local-media-mount` (4Gi) | X | X | X | X |
+| `uploads-files` (40Gi) | | X | X | X |
+| `gak-public` (4Gi) | | | | X |
+| `gak-private` (4Gi) | | | | X |
+
+### Tiers and telemetry
+
+Telemetry is orthogonal to the deployment tier. It is controlled independently via `global.ENABLE_OPEN_TELEMETRY` (default: `true`). When enabled, the telemetry stack (otel-collector, Grafana, Prometheus, Jaeger, DCGM exporter, node exporter) deploys alongside whichever tier is selected. Services that are deployed export traces and metrics automatically; services not included in the tier simply don't emit data.
+
 ## Install Graphistry
-Graphistry v2.50.0+ uses RAPIDS 26.02 and publishes Docker images in two flavors: CUDA 12 and CUDA 13. The `cuda.version` chart value accepts `"12"` or `"13"` and selects which image variant to pull (e.g., `graphistry/nexus:v2.50.0-12`). Internally, Graphistry builds on top of RAPIDS base images (`rapidsai/base:26.02-cuda12-py3.10` and `rapidsai/base:26.02-cuda13-py3.10`), which ship specific CUDA toolkit versions that determine the minimum driver requirement:
+Graphistry v2.50.1+ uses RAPIDS 26.02 and publishes Docker images in two flavors: CUDA 12 and CUDA 13. The `cuda.version` chart value accepts `"12"` or `"13"` and selects which image variant to pull (e.g., `graphistry/nexus:v2.50.1-12`). Internally, Graphistry builds on top of RAPIDS base images (`rapidsai/base:26.02-cuda12-py3.10` and `rapidsai/base:26.02-cuda13-py3.10`), which ship specific CUDA toolkit versions that determine the minimum driver requirement:
 
 | Graphistry Build | RAPIDS | CUDA Toolkit in Image | Recommended Min Driver | Verified On |
 |---|---|---|---|---|
-| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | GKE: R570 (570.133.20, T4, forward compat). k3s: R575 (575.57.08), R580 (580.126.20), R590 (590.44.01) |
-| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | k3s: R590 (590.44.01). Docker compose: R590 (590.48.01) |
+| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | GKE: R570 (570.133.20, T4, forward compat). k3s: R575 (575.57.08), R580 (580.126.20), R590 (590.44.01), R595 (595.58.03) |
+| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | k3s: R590 (590.44.01), R595 (595.58.03). Docker compose: R590 (590.48.01) |
 
 We recommend the driver versions in the table above. Older drivers may work via NVIDIA's [forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) layer but are not verified by Graphistry. The CUDA 13 flavor requires R590+ because the RAPIDS 26.02 base image (`rapidsai/base:26.02-cuda13-py3.10`) bakes CUDA 13.1 runtime (`CUDA_VERSION=13.1.0`), not 13.0. See the [RAPIDS Platform Support](https://docs.rapids.ai/platform-support/) matrix and [NVIDIA CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/) for the full driver compatibility matrix.
 
@@ -489,7 +543,7 @@ cuda:
   version: "12"   # or "13" - must match the GPU driver installed above
 
 global:  ## global settings for all charts
-  tag: v2.50.0
+  tag: v2.50.1
 ```
 
 Also verify that the values file references the correct Docker Hub pull secret ([Create Docker Hub Secret](#create-docker-hub-secret)) and StorageClass configuration ([Configure StorageClass](#configure-storageclass)):
@@ -585,6 +639,7 @@ When updating, preserve existing volume bindings so that data persists across re
 echo "volumeName:
   dataMount: $(kubectl get pvc data-mount -n graphistry -o jsonpath='{.spec.volumeName}')
   localMediaMount: $(kubectl get pvc local-media-mount -n graphistry -o jsonpath='{.spec.volumeName}')
+  uploadsFiles: $(kubectl get pvc uploads-files -n graphistry -o jsonpath='{.spec.volumeName}')
   gakPublic: $(kubectl get pvc gak-public -n graphistry -o jsonpath='{.spec.volumeName}')
   gakPrivate: $(kubectl get pvc gak-private -n graphistry -o jsonpath='{.spec.volumeName}')"
 ```

--- a/charts/values-overrides/examples/gke/gke_example_values.yaml
+++ b/charts/values-overrides/examples/gke/gke_example_values.yaml
@@ -26,6 +26,13 @@ cuda:
   version: "12"
 
 global:
+  # Deployment tier. Each tier includes all capabilities of the previous tiers.
+  # platform  -> nexus + postgres (minimum tier, auth provider, foundation for Louie or other integrations)
+  # analytics -> platform + fep + dask + redis + nginx + caddy (GPU compute, ETL, GFQL, API)
+  # viz       -> analytics + streamgl (interactive graph visualization, WebGL, real-time layout)
+  # full      -> viz + gak + notebook + pivot (dashboards, Jupyter, all tools)
+  tier: "full"
+
   # GKE storage provisioner
   provisioner: pd.csi.storage.gke.io
 
@@ -41,7 +48,7 @@ global:
     nvidia.com/gpu.present: "true"
 
   # Graphistry version
-  tag: v2.50.0
+  tag: v2.50.1
 
   # Image settings
   imagePullPolicy: Always

--- a/charts/values-overrides/examples/gke/gke_example_values.yaml
+++ b/charts/values-overrides/examples/gke/gke_example_values.yaml
@@ -66,7 +66,7 @@ global:
   # Telemetry stack configuration
   # Documentation: https://github.com/graphistry/graphistry-cli/blob/master/docs/tools/telemetry.md#kubernetes-deployment
   telemetryStack:
-    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials bellow
+    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials below
     openTelemetryCollector:
       OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT: ""   # e.g. Grafana OTLP HTTP endpoint for Graphistry Hub https://otlp-gateway-prod-us-east-0.grafana.net/otlp
       OTEL_COLLECTOR_OTLP_USERNAME: ""   # e.g. Grafana Cloud Instance ID for OTLP

--- a/charts/values-overrides/examples/k3s/README.md
+++ b/charts/values-overrides/examples/k3s/README.md
@@ -18,10 +18,11 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server \
     --default-runtime nvidia \
     --write-kubeconfig-mode 640 \
     --write-kubeconfig-group <your-group> \
-    --node-name <your-node-name>" sh -
+    --node-name <your-node-name> \
+    --data-dir <your-data-dir>" sh -
 ```
 
-Replace `<your-group>` with the OS group whose members should have kubectl access (e.g., your user's group, `graphistry`, `docker`, `sudo`), and `<your-node-name>` with a name for this node.
+Replace `<your-group>` with the OS group whose members should have kubectl access (e.g., your user's group, `graphistry`, `docker`, `sudo`), `<your-node-name>` with a name for this node, and `<your-data-dir>` with the path where k3s stores its data (images, PVCs, state).
 
 | Flag | Purpose |
 |------|---------|
@@ -29,6 +30,7 @@ Replace `<your-group>` with the OS group whose members should have kubectl acces
 | `--write-kubeconfig-mode 640` | Makes kubeconfig readable by group members (default is 600, root-only) |
 | `--write-kubeconfig-group <group>` | Sets the group owner of `/etc/rancher/k3s/k3s.yaml` |
 | `--node-name <name>` | Sets a custom node name instead of the hostname |
+| `--data-dir <path>` | Optional. Where k3s stores images, PVCs, and state. Defaults to `/var/lib/rancher/k3s` (root disk). Graphistry images are large (~14GB each), so use a separate disk if root has limited space (e.g., `--data-dir /mnt/data/var/lib/rancher/k3s`). Can also be set later via `/etc/rancher/k3s/config.yaml` with `data-dir: /mnt/data/var/lib/rancher/k3s` |
 
 Set up KUBECONFIG so `kubectl` and `helm` work as a non-root user. The recommended approach is per-user via your shell's rc file since it is permanent and under the control of the user running the deployment:
 
@@ -83,12 +85,12 @@ helm install --wait --generate-name \
     --timeout 60m
 ```
 
-Graphistry v2.50.0+ uses RAPIDS 26.02 and publishes Docker images in two flavors: CUDA 12 and CUDA 13. The `cuda.version` chart value accepts `"12"` or `"13"` and selects which image variant to pull (e.g., `graphistry/nexus:v2.50.0-12`). Internally, Graphistry builds on top of RAPIDS base images (`rapidsai/base:26.02-cuda12-py3.10` and `rapidsai/base:26.02-cuda13-py3.10`), which ship specific CUDA toolkit versions that determine the minimum driver requirement:
+Graphistry v2.50.1+ uses RAPIDS 26.02 and publishes Docker images in two flavors: CUDA 12 and CUDA 13. The `cuda.version` chart value accepts `"12"` or `"13"` and selects which image variant to pull (e.g., `graphistry/nexus:v2.50.1-12`). Internally, Graphistry builds on top of RAPIDS base images (`rapidsai/base:26.02-cuda12-py3.10` and `rapidsai/base:26.02-cuda13-py3.10`), which ship specific CUDA toolkit versions that determine the minimum driver requirement:
 
 | Graphistry Build | RAPIDS | CUDA Toolkit in Image | Recommended Min Driver | Verified On |
 |---|---|---|---|---|
-| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | k3s: R575 (575.57.08), R580 (580.126.20), R590 (590.44.01). GKE: R570 (570.133.20, T4, forward compat) |
-| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | k3s: R590 (590.44.01). Docker compose: R590 (590.48.01) |
+| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | k3s: R575 (575.57.08), R580 (580.126.20), R590 (590.44.01), R595 (595.58.03). GKE: R570 (570.133.20, T4, forward compat) |
+| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | k3s: R590 (590.44.01), R595 (595.58.03). Docker compose: R590 (590.48.01) |
 
 We recommend the driver versions in the table above. Older drivers may work via NVIDIA's [forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) layer but are not verified by Graphistry. The chart default is `cuda.version: "12"`. The CUDA 13 flavor requires R590+ because the RAPIDS 26.02 base image (`rapidsai/base:26.02-cuda13-py3.10`) bakes CUDA 13.1 runtime (`CUDA_VERSION=13.1.0`), not 13.0. See the [RAPIDS Platform Support](https://docs.rapids.ai/platform-support/) matrix and [NVIDIA CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/) for the full driver compatibility matrix.
 
@@ -279,7 +281,9 @@ global:
 | `gak-private` | graph-app-kit-private, notebook |
 | `uploads-files` | nginx, forge-etl-python |
 
-**Note**: The Postgres Cluster also requires the same StorageClass.
+**Notes**:
+- The Postgres Cluster also requires the same StorageClass.
+- The notebook service mounts `data-mount` at `/home/graphistry/notebooks/` (subPath: `notebooks`). Only files saved under this directory persist across redeployments. The default demo notebooks at `/home/graphistry/demos/` are baked into the Docker image and reset when the image tag changes. To preserve your work, save or copy notebooks to `/home/graphistry/notebooks/`.
 
 ## Install Postgres Cluster
 
@@ -315,6 +319,58 @@ kubectl get pods --watch -n graphistry
 
 **Note**: If pods stay in `Pending` state, verify the StorageClass is correctly configured (see [Configure StorageClass](#configure-storageclass)).
 
+## Deployment Tiers
+
+Graphistry supports four deployment tiers, each building on the previous. Set `global.tier` in your values file to control which services are deployed:
+
+```yaml
+global:
+  tier: "full"   # platform | analytics | viz | full
+```
+
+Each tier includes all capabilities of the previous tiers:
+
+| Tier | Description | GPU Required |
+|------|-------------|:------------:|
+| `platform` | `postgres` + `nexus`. Auth provider, foundation for Louie or other integrations. Minimum tier, services in the same namespace connect internally via `http://nexus:8000`. For external access use port-forward (`kubectl port-forward -n graphistry svc/nexus 8000:8000`) or create an Ingress. | No |
+| `analytics` | `platform` + `caddy`, `nginx`, `redis`, `dask-scheduler`, `dask-cuda-worker`, `forge-etl-python`. Public API access, GPU compute, ETL processing and GFQL graph queries. | Yes |
+| `viz` | `analytics` + `streamgl-sessions`, `streamgl-gpu`, `streamgl-viz`. Interactive graph visualization with WebGL rendering and real-time GPU layout. | Yes |
+| `full` | `viz` + `pivot`, `notebook`, `graph-app-kit` (public/private). Investigation tools (Pivot), Jupyter notebooks and Streamlit dashboards. **Default tier**. | Yes |
+
+### Services per tier
+
+| Service | platform | analytics | viz | full |
+|---------|:--------:|:---------:|:---:|:----:|
+| `postgres` (postgres-cluster chart) | X | X | X | X |
+| `nexus` | X | X | X | X |
+| `caddy` | | X | X | X |
+| `nginx` | | X | X | X |
+| `redis` | | X | X | X |
+| `dask-scheduler` | | X | X | X |
+| `dask-cuda-worker` | | X | X | X |
+| `forge-etl-python` | | X | X | X |
+| `streamgl-sessions` | | | X | X |
+| `streamgl-gpu` | | | X | X |
+| `streamgl-viz` | | | X | X |
+| `pivot` | | | | X |
+| `notebook` | | | | X |
+| `graph-app-kit-public` | | | | X |
+| `graph-app-kit-private` | | | | X |
+
+### PVCs per tier
+
+| PVC | platform | analytics | viz | full |
+|-----|:--------:|:---------:|:---:|:----:|
+| `data-mount` (64Gi) | X | X | X | X |
+| `local-media-mount` (4Gi) | X | X | X | X |
+| `uploads-files` (40Gi) | | X | X | X |
+| `gak-public` (4Gi) | | | | X |
+| `gak-private` (4Gi) | | | | X |
+
+### Tiers and telemetry
+
+Telemetry is orthogonal to the deployment tier. It is controlled independently via `global.ENABLE_OPEN_TELEMETRY` (default: `true`). When enabled, the telemetry stack (otel-collector, Grafana, Prometheus, Jaeger, DCGM exporter, node exporter) deploys alongside whichever tier is selected. Services that are deployed export traces and metrics automatically; services not included in the tier simply don't emit data.
+
 ## Install Graphistry
 
 You can set the CUDA and Graphistry versions by editing `./charts/values-overrides/examples/k3s/k3s_example_values.yaml` (see the driver compatibility table in the [GPU Support](#option-1-nvidia-gpu-operator-recommended) section above for accepted `cuda.version` values and driver requirements):
@@ -323,7 +379,7 @@ cuda:
   version: "13"   # or "12" - must match the GPU driver installed above
 
 global:  ## global settings for all charts
-  tag: v2.50.0
+  tag: v2.50.1
 ```
 
 Also verify that the values file references the correct Docker Hub pull secret ([Create Docker Hub Secret](#create-docker-hub-secret)) and StorageClass configuration ([Configure StorageClass](#configure-storageclass)):
@@ -384,6 +440,7 @@ When updating, preserve existing volume bindings so that data persists across re
 echo "volumeName:
   dataMount: $(kubectl get pvc data-mount -n graphistry -o jsonpath='{.spec.volumeName}')
   localMediaMount: $(kubectl get pvc local-media-mount -n graphistry -o jsonpath='{.spec.volumeName}')
+  uploadsFiles: $(kubectl get pvc uploads-files -n graphistry -o jsonpath='{.spec.volumeName}')
   gakPublic: $(kubectl get pvc gak-public -n graphistry -o jsonpath='{.spec.volumeName}')
   gakPrivate: $(kubectl get pvc gak-private -n graphistry -o jsonpath='{.spec.volumeName}')"
 ```
@@ -396,9 +453,15 @@ helm upgrade -i g-chart ./charts/graphistry-helm \
     --namespace graphistry --create-namespace
 ```
 
-If pods stay in `Pending` state after a reinstall, the PVs may have a stale `claimRef`. This commonly happens when you `helm uninstall` the Graphistry chart and then reinstall it: the StorageClass uses `reclaimPolicy: Retain`, so the PVs survive the uninstall but remain bound to the old (now deleted) PVCs. The new PVCs cannot bind to those PVs until the stale `claimRef` is cleared:
+If pods stay in `Pending` state after a reinstall, the PVs may have a stale `claimRef`. This commonly happens when you `helm uninstall` the Graphistry chart and then reinstall it: the StorageClass uses `reclaimPolicy: Retain`, so the PVs survive the uninstall but remain bound to the old (now deleted) PVCs. The new PVCs cannot bind to those PVs until the stale `claimRef` is cleared.
+
+After `helm uninstall`, PVs take up to 60 seconds to transition from `Bound` to `Released`. Watch for the transition before clearing the claimRef:
 
 ```bash
+# Watch until PVs show Released (Ctrl+C once you see them)
+kubectl get pv --watch | grep Released
+
+# Then clear the stale claimRef
 kubectl get pv -o json | \
     jq -r '.items[] | select(.status.phase=="Released") | select(.spec.claimRef.namespace=="graphistry") | .metadata.name' | \
     xargs -I {} kubectl patch pv {} -p '{"spec":{"claimRef": null}}'

--- a/charts/values-overrides/examples/k3s/k3s_example_values.yaml
+++ b/charts/values-overrides/examples/k3s/k3s_example_values.yaml
@@ -272,11 +272,18 @@ forgeWorkers: "1" #sets the number of forge workers recommend 1 per 4 GB GPU mem
 
 # CUDA version - 12 or 13
 cuda:
-  version: "12"
+  version: "13"
 
 global:  ## global settings for all charts
+  # Deployment tier. Each tier includes all capabilities of the previous tiers.
+  # platform  -> nexus + postgres (foundation, auth provider for Louie or other integrations)
+  # analytics -> platform + fep + dask + redis + nginx + caddy (GPU compute, ETL, GFQL, API)
+  # viz       -> analytics + streamgl (interactive graph visualization, WebGL, real-time layout)
+  # full      -> viz + gak + notebook + pivot (dashboards, Jupyter, all tools)
+  tier: "full"
+
   # Graphistry version: Your Docker Hub account must have access to Graphistry images (Contact Graphistry Support: https://www.graphistry.com/support to get access).
-  tag: v2.50.0
+  tag: v2.50.1
 
   # For new K8s versions (e.g. GKE) that don't need anymore the legacy annotation kubernetes.io/ingress.class: traefik
   ingressClassName: traefik
@@ -314,8 +321,8 @@ global:  ## global settings for all charts
     - name: docker-secret-prod
   # Log levels: INFO (default), DEBUG, TRACE (for troubleshooting)
   logs:
-    LogLevel: INFO
-    GraphistryLogLevel: INFO
+    LogLevel: DEBUG
+    GraphistryLogLevel: DEBUG
   # Telemetry: https://graphistry-admin-docs.readthedocs.io/en/latest/telemetry/kubernetes.html
   ENABLE_OPEN_TELEMETRY: true
 
@@ -422,6 +429,11 @@ env: #environment variables
    value: "false"
  - name: ACME_AGREE
    value: "true"
+ # URL used by the browser to reach Graphistry (e.g., for notebook iframe rendering).
+ # Set to your external domain for production (e.g., https://graphistry.example.com).
+ # For local testing without a domain, use http://localhost.
+ - name: GRAPHISTRY_CLIENT_PROTOCOL_HOSTNAME                                                                               
+   value: "http://localhost"
 
 ##streamlit environment variables
  ## can be set like helm upgrade -i  chart_name --name release_name \

--- a/charts/values-overrides/examples/k3s/k3s_example_values.yaml
+++ b/charts/values-overrides/examples/k3s/k3s_example_values.yaml
@@ -272,7 +272,7 @@ forgeWorkers: "1" #sets the number of forge workers recommend 1 per 4 GB GPU mem
 
 # CUDA version - 12 or 13
 cuda:
-  version: "13"
+  version: "12"
 
 global:  ## global settings for all charts
   # Deployment tier. Each tier includes all capabilities of the previous tiers.
@@ -321,8 +321,8 @@ global:  ## global settings for all charts
     - name: docker-secret-prod
   # Log levels: INFO (default), DEBUG, TRACE (for troubleshooting)
   logs:
-    LogLevel: DEBUG
-    GraphistryLogLevel: DEBUG
+    LogLevel: INFO
+    GraphistryLogLevel: INFO
   # Telemetry: https://graphistry-admin-docs.readthedocs.io/en/latest/telemetry/kubernetes.html
   ENABLE_OPEN_TELEMETRY: true
 

--- a/charts/values-overrides/examples/tanzu/README.md
+++ b/charts/values-overrides/examples/tanzu/README.md
@@ -190,12 +190,12 @@ helm install --wait --generate-name \
 
 **Choose `<DRIVER_VERSION>` based on your CUDA version:**
 
-Graphistry v2.50.0+ uses RAPIDS 26.02 and publishes Docker images in two flavors: CUDA 12 and CUDA 13. The `cuda.version` chart value accepts `"12"` or `"13"` and selects which image variant to pull (e.g., `graphistry/nexus:v2.50.0-12`). Internally, Graphistry builds on top of RAPIDS base images (`rapidsai/base:26.02-cuda12-py3.10` and `rapidsai/base:26.02-cuda13-py3.10`), which ship specific CUDA toolkit versions that determine the minimum driver requirement:
+Graphistry v2.50.1+ uses RAPIDS 26.02 and publishes Docker images in two flavors: CUDA 12 and CUDA 13. The `cuda.version` chart value accepts `"12"` or `"13"` and selects which image variant to pull (e.g., `graphistry/nexus:v2.50.1-12`). Internally, Graphistry builds on top of RAPIDS base images (`rapidsai/base:26.02-cuda12-py3.10` and `rapidsai/base:26.02-cuda13-py3.10`), which ship specific CUDA toolkit versions that determine the minimum driver requirement:
 
 | Graphistry Build | RAPIDS | CUDA Toolkit in Image | Recommended Min Driver | Verified On |
 |---|---|---|---|---|
-| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | k3s: R575 (575.57.08), R580 (580.126.20), R590 (590.44.01). GKE: R570 (570.133.20, T4, forward compat) |
-| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | k3s: R590 (590.44.01). Docker compose: R590 (590.48.01) |
+| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | k3s: R575 (575.57.08), R580 (580.126.20), R590 (590.44.01), R595 (595.58.03). GKE: R570 (570.133.20, T4, forward compat) |
+| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | k3s: R590 (590.44.01), R595 (595.58.03). Docker compose: R590 (590.48.01) |
 
 We recommend the driver versions in the table above. Older drivers may work via NVIDIA's [forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) layer but are not verified by Graphistry. The chart default is `cuda.version: "12"`. The CUDA 13 flavor requires R590+ because the RAPIDS 26.02 base image (`rapidsai/base:26.02-cuda13-py3.10`) bakes CUDA 13.1 runtime (`CUDA_VERSION=13.1.0`), not 13.0. See the [RAPIDS Platform Support](https://docs.rapids.ai/platform-support/) matrix, [NVIDIA CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/) for the full driver compatibility matrix, and the [GPU Operator Component Matrix](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html#gpu-operator-component-matrix) for supported driver versions per operator release.
 
@@ -279,8 +279,8 @@ For environments with limited or no internet access, update your values file:
 global:
   # Redirect image pulls to your private registry
   # Images are pulled as: <containerregistry.name>/<image>:<tag>
-  # Default: docker.io/graphistry (e.g., docker.io/graphistry/nexus:v2.50.0-12)
-  # Air-gapped: my-registry.local/graphistry (e.g., my-registry.local/graphistry/nexus:v2.50.0-12)
+  # Default: docker.io/graphistry (e.g., docker.io/graphistry/nexus:v2.50.1-12)
+  # Air-gapped: my-registry.local/graphistry (e.g., my-registry.local/graphistry/nexus:v2.50.1-12)
   containerregistry:
     name: my-private-registry.local/graphistry
 
@@ -414,7 +414,9 @@ global:
 | `gak-private` | graph-app-kit-private, notebook |
 | `uploads-files` | nginx, forge-etl-python |
 
-**Note**: The Postgres Cluster also requires the same StorageClass.
+**Notes**:
+- The Postgres Cluster also requires the same StorageClass.
+- The notebook service mounts `data-mount` at `/home/graphistry/notebooks/` (subPath: `notebooks`). Only files saved under this directory persist across redeployments. The default demo notebooks at `/home/graphistry/demos/` are baked into the Docker image and reset when the image tag changes. To preserve your work, save or copy notebooks to `/home/graphistry/notebooks/`.
 
 ## Install Postgres Cluster
 
@@ -450,6 +452,58 @@ kubectl get pods --watch -n graphistry
 
 **Note**: If pods stay in `Pending` state, verify the StorageClass is correctly configured (see [Configure StorageClass](#configure-storageclass)).
 
+## Deployment Tiers
+
+Graphistry supports four deployment tiers, each building on the previous. Set `global.tier` in your values file to control which services are deployed:
+
+```yaml
+global:
+  tier: "full"   # platform | analytics | viz | full
+```
+
+Each tier includes all capabilities of the previous tiers:
+
+| Tier | Description | GPU Required |
+|------|-------------|:------------:|
+| `platform` | `postgres` + `nexus`. Auth provider, foundation for Louie or other integrations. Minimum tier, services in the same namespace connect internally via `http://nexus:8000`. For external access use port-forward (`kubectl port-forward -n graphistry svc/nexus 8000:8000`) or create an Ingress. | No |
+| `analytics` | `platform` + `caddy`, `nginx`, `redis`, `dask-scheduler`, `dask-cuda-worker`, `forge-etl-python`. Public API access, GPU compute, ETL processing and GFQL graph queries. | Yes |
+| `viz` | `analytics` + `streamgl-sessions`, `streamgl-gpu`, `streamgl-viz`. Interactive graph visualization with WebGL rendering and real-time GPU layout. | Yes |
+| `full` | `viz` + `pivot`, `notebook`, `graph-app-kit` (public/private). Investigation tools (Pivot), Jupyter notebooks and Streamlit dashboards. **Default tier**. | Yes |
+
+### Services per tier
+
+| Service | platform | analytics | viz | full |
+|---------|:--------:|:---------:|:---:|:----:|
+| `postgres` (postgres-cluster chart) | X | X | X | X |
+| `nexus` | X | X | X | X |
+| `caddy` | | X | X | X |
+| `nginx` | | X | X | X |
+| `redis` | | X | X | X |
+| `dask-scheduler` | | X | X | X |
+| `dask-cuda-worker` | | X | X | X |
+| `forge-etl-python` | | X | X | X |
+| `streamgl-sessions` | | | X | X |
+| `streamgl-gpu` | | | X | X |
+| `streamgl-viz` | | | X | X |
+| `pivot` | | | | X |
+| `notebook` | | | | X |
+| `graph-app-kit-public` | | | | X |
+| `graph-app-kit-private` | | | | X |
+
+### PVCs per tier
+
+| PVC | platform | analytics | viz | full |
+|-----|:--------:|:---------:|:---:|:----:|
+| `data-mount` (64Gi) | X | X | X | X |
+| `local-media-mount` (4Gi) | X | X | X | X |
+| `uploads-files` (40Gi) | | X | X | X |
+| `gak-public` (4Gi) | | | | X |
+| `gak-private` (4Gi) | | | | X |
+
+### Tiers and telemetry
+
+Telemetry is orthogonal to the deployment tier. It is controlled independently via `global.ENABLE_OPEN_TELEMETRY` (default: `true`). When enabled, the telemetry stack (otel-collector, Grafana, Prometheus, Jaeger, DCGM exporter, node exporter) deploys alongside whichever tier is selected. Services that are deployed export traces and metrics automatically; services not included in the tier simply don't emit data.
+
 ## Install Graphistry
 
 You can set the CUDA and Graphistry versions by editing `./charts/values-overrides/examples/tanzu/tanzu_example_values.yaml`:
@@ -458,7 +512,7 @@ cuda:
   version: "12"   # or "13" - must match the GPU driver installed above
 
 global:  ## global settings for all charts
-  tag: v2.50.0
+  tag: v2.50.1
 ```
 
 Also verify that the values file references the correct Docker Hub pull secret ([Create Docker Hub Secret](#create-docker-hub-secret)) and StorageClass configuration ([Configure StorageClass](#configure-storageclass)):
@@ -514,6 +568,7 @@ When updating, preserve existing volume bindings so that data persists across re
 echo "volumeName:
   dataMount: $(kubectl get pvc data-mount -n graphistry -o jsonpath='{.spec.volumeName}')
   localMediaMount: $(kubectl get pvc local-media-mount -n graphistry -o jsonpath='{.spec.volumeName}')
+  uploadsFiles: $(kubectl get pvc uploads-files -n graphistry -o jsonpath='{.spec.volumeName}')
   gakPublic: $(kubectl get pvc gak-public -n graphistry -o jsonpath='{.spec.volumeName}')
   gakPrivate: $(kubectl get pvc gak-private -n graphistry -o jsonpath='{.spec.volumeName}')"
 ```

--- a/charts/values-overrides/examples/tanzu/tanzu_example_values.yaml
+++ b/charts/values-overrides/examples/tanzu/tanzu_example_values.yaml
@@ -20,6 +20,13 @@ k8sDashboard:
   createServiceAccount: false
 
 global:
+  # Deployment tier. Each tier includes all capabilities of the previous tiers.
+  # platform  -> nexus + postgres (minimum tier, auth provider, foundation for Louie or other integrations)
+  # analytics -> platform + fep + dask + redis + nginx + caddy (GPU compute, ETL, GFQL, API)
+  # viz       -> analytics + streamgl (interactive graph visualization, WebGL, real-time layout)
+  # full      -> viz + gak + notebook + pivot (dashboards, Jupyter, all tools)
+  tier: "full"
+
   # Ingress class - change to "traefik" if using Traefik ingress controller
   ingressClassName: nginx
 
@@ -42,7 +49,7 @@ global:
     nvidia.com/gpu.present: "true"
 
   # Graphistry version
-  tag: v2.50.0
+  tag: v2.50.1
 
   # Image settings
   imagePullPolicy: Always

--- a/charts/values-overrides/examples/tanzu/tanzu_example_values.yaml
+++ b/charts/values-overrides/examples/tanzu/tanzu_example_values.yaml
@@ -62,7 +62,7 @@ global:
   # Telemetry stack configuration
   # Documentation: https://github.com/graphistry/graphistry-cli/blob/master/docs/tools/telemetry.md#kubernetes-deployment
   telemetryStack:
-    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials bellow
+    OTEL_CLOUD_MODE: false   # false: deploy our stack: jaeger, prometheus, grafana etc.; else fill OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT and credentials below
     openTelemetryCollector:
       OTEL_COLLECTOR_OTLP_HTTP_ENDPOINT: ""   # e.g. Grafana OTLP HTTP endpoint for Graphistry Hub https://otlp-gateway-prod-us-east-0.grafana.net/otlp
       OTEL_COLLECTOR_OTLP_USERNAME: ""   # e.g. Grafana Cloud Instance ID for OTLP

--- a/charts/values-overrides/examples/troubleshooting.md
+++ b/charts/values-overrides/examples/troubleshooting.md
@@ -339,7 +339,7 @@ kubectl exec -n gpu-operator $(kubectl get pods -n gpu-operator -o name | grep d
 
 This confirms the driver is functional and shows the GPU model, driver version, CUDA version, memory, and temperature. If this command fails, the driver is not working correctly and must be fixed before proceeding. See [Troubleshoot and Debug](#troubleshoot-and-debug-1) below.
 
-Verify the GPU is usable by Graphistry CUDA containers. The previous step confirmed the GPU Operator pods can access the GPU. This step verifies that a standalone CUDA container can also use it, which is how Graphistry services run. Graphistry v2.50.0+ supports CUDA 12 and CUDA 13 (see driver compatibility table below).
+Verify the GPU is usable by Graphistry CUDA containers. The previous step confirmed the GPU Operator pods can access the GPU. This step verifies that a standalone CUDA container can also use it, which is how Graphistry services run. Graphistry v2.50.1+ supports CUDA 12 and CUDA 13 (see driver compatibility table below).
 
 ```bash
 # Graphistry supports CUDA 12 (driver 535+) and CUDA 13 (driver 590+). Test with the version matching your driver.
@@ -376,14 +376,14 @@ pod "graphistry-gpu-test-3407611" deleted from default namespace
 
 > **Note (Tanzu vGPU):** In vGPU mode, nvidia-smi will show the **vGPU profile name** instead of the physical GPU model (e.g., `NVIDIA A100-4C` instead of `NVIDIA A100-PCIE-40GB`), and memory will reflect the vGPU allocation, not the full physical GPU memory. It will also display a `vGPU Software License Status` line showing `Licensed` (with expiry) or `Unlicensed`. If it shows `Unlicensed`, verify the licensing secret (`gridd.conf` and `client_configuration_token.tok`) in the `gpu-operator` namespace. See the [Tanzu README](tanzu/README.md) for vGPU licensing setup.
 
-**Driver compatibility for Graphistry v2.50.0+ CUDA images** (sources: [RAPIDS Platform Support](https://docs.rapids.ai/platform-support/), [CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/)):
+**Driver compatibility for Graphistry v2.50.1+ CUDA images** (sources: [RAPIDS Platform Support](https://docs.rapids.ai/platform-support/), [CUDA Toolkit Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/)):
 
-Graphistry v2.50.0+ uses RAPIDS 26.02 and publishes two flavors: CUDA 12 and CUDA 13. The `cuda.version` chart value accepts `"12"` or `"13"`. Internally, Graphistry builds on top of RAPIDS base images (`rapidsai/base:26.02-cuda12-py3.10` and `rapidsai/base:26.02-cuda13-py3.10`), which ship specific CUDA toolkit versions that determine the minimum driver requirement:
+Graphistry v2.50.1+ uses RAPIDS 26.02 and publishes two flavors: CUDA 12 and CUDA 13. The `cuda.version` chart value accepts `"12"` or `"13"`. Internally, Graphistry builds on top of RAPIDS base images (`rapidsai/base:26.02-cuda12-py3.10` and `rapidsai/base:26.02-cuda13-py3.10`), which ship specific CUDA toolkit versions that determine the minimum driver requirement:
 
 | Graphistry Build | RAPIDS | CUDA Toolkit in Image | Recommended Min Driver | Verified On |
 |---|---|---|---|---|
-| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | k3s: R575 (575.57.08), R580 (580.126.20), R590 (590.44.01). GKE: R570 (570.133.20, T4, forward compat) |
-| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | k3s: R590 (590.44.01). Docker compose: R590 (590.48.01) |
+| `cuda.version: "12"` | 26.02 | 12.9.1 | R575+ (575.51.03+) | k3s: R575 (575.57.08), R580 (580.126.20), R590 (590.44.01), R595 (595.58.03). GKE: R570 (570.133.20, T4, forward compat) |
+| `cuda.version: "13"` | 26.02 | 13.1.0 | R590+ (590.44.01+) | k3s: R590 (590.44.01), R595 (595.58.03). Docker compose: R590 (590.48.01) |
 
 We recommend the driver versions in the table above. Older drivers may work via NVIDIA's [forward compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/) layer but are not verified by Graphistry.
 
@@ -3309,6 +3309,7 @@ Before running `helm upgrade` or after a `helm uninstall` + reinstall, generate 
 echo "volumeName:
   dataMount: $(kubectl get pvc data-mount -n graphistry -o jsonpath='{.spec.volumeName}')
   localMediaMount: $(kubectl get pvc local-media-mount -n graphistry -o jsonpath='{.spec.volumeName}')
+  uploadsFiles: $(kubectl get pvc uploads-files -n graphistry -o jsonpath='{.spec.volumeName}')
   gakPublic: $(kubectl get pvc gak-public -n graphistry -o jsonpath='{.spec.volumeName}')
   gakPrivate: $(kubectl get pvc gak-private -n graphistry -o jsonpath='{.spec.volumeName}')"
 ```
@@ -3319,6 +3320,7 @@ Expected output:
 volumeName:
   dataMount: pvc-6327f91b-8c7f-4644-93b1-e3eb6f79b49a
   localMediaMount: pvc-76680b21-4688-4c81-a79e-b01317a6f4db
+  uploadsFiles: pvc-a417fc34-2128-4824-99de-a3267e21e4dc
   gakPublic: pvc-fbcee9c7-c985-4c73-8f79-74943eae87a3
   gakPrivate: pvc-7e49e1e1-de5f-4847-821b-041d4376d941
 ```
@@ -3341,15 +3343,19 @@ This is normal behavior with `reclaimPolicy: Retain`. The PV preserves your data
 
 **PVC Pending after reinstall (PV claimRef still points to old PVC):**
 
-If you did not set `volumeName` in your values file and the PVC stays Pending, the PV's `claimRef` still points to the old (deleted) PVC. Clear the claimRef on all Released PVs belonging to the graphistry namespace:
+If you did not set `volumeName` in your values file and the PVC stays Pending, the PV's `claimRef` still points to the old (deleted) PVC. After `helm uninstall`, PVs take up to 60 seconds to transition from `Bound` to `Released`. Watch for the transition before clearing the claimRef:
 
 ```bash
+# Watch until PVs show Released (Ctrl+C once you see them)
+kubectl get pv --watch | grep Released
+
+# Then clear the stale claimRef
 kubectl get pv -o json | \
     jq -r '.items[] | select(.status.phase=="Released") | select(.spec.claimRef.namespace=="graphistry") | .metadata.name' | \
     xargs -I {} kubectl patch pv {} -p '{"spec":{"claimRef": null}}'
 ```
 
-If the command produces no output, there are no Released PVs to patch (all PVs are already Bound, which is the healthy state). After patching, the PVCs should automatically bind to the freed PVs. However, using `volumeName` in the values file (as shown above) is the recommended approach because it avoids this issue entirely.
+After patching, the PVCs should automatically bind to the freed PVs. However, using `volumeName` in the values file (as shown above) is the recommended approach because it avoids this issue entirely.
 
 **Stale volumeName pointing to deleted PVs (fresh deployment after full cleanup):**
 
@@ -3397,6 +3403,7 @@ The root cause is `volumeName` in your values file pinning PVCs to PVs that were
 volumeName:
   dataMount: pvc-6327f91b-8c7f-4644-93b1-e3eb6f79b49a
   localMediaMount: pvc-76680b21-4688-4c81-a79e-b01317a6f4db
+  uploadsFiles: pvc-a417fc34-2128-4824-99de-a3267e21e4dc
   gakPublic: pvc-fbcee9c7-c985-4c73-8f79-74943eae87a3
   gakPrivate: pvc-7e49e1e1-de5f-4847-821b-041d4376d941
 ```
@@ -3407,6 +3414,7 @@ For a fresh deployment, comment out or remove the `volumeName` block in your val
 #volumeName:
 #  dataMount:
 #  localMediaMount:
+#  uploadsFiles:
 #  gakPublic:
 #  gakPrivate:
 ```

--- a/docs/source/10mins-to-k8s.rst
+++ b/docs/source/10mins-to-k8s.rst
@@ -43,7 +43,7 @@ GPU Operator (Recommended)
 
 Set ``--set driver.enabled=true`` and ``--set driver.version="<VERSION>"`` if the NVIDIA driver is not already installed on the host.
 
-Graphistry v2.50.0+ uses RAPIDS 26.02 and publishes images in two flavors: CUDA 12 and CUDA 13. The ``cuda.version`` chart value accepts ``"12"`` or ``"13"``. The GPU driver must be compatible with the chosen CUDA version:
+Graphistry v2.50.1+ uses RAPIDS 26.02 and publishes images in two flavors: CUDA 12 and CUDA 13. The ``cuda.version`` chart value accepts ``"12"`` or ``"13"``. The GPU driver must be compatible with the chosen CUDA version:
 
 =============== ====== ================ ========================== ===============================================
 Build           RAPIDS CUDA Toolkit     Recommended Min Driver     Verified On
@@ -197,6 +197,75 @@ Wait for postgres pods to be running:
     kubectl get pods --watch -n graphistry
 
 
+Deployment Tiers
+----------------
+
+Graphistry v2.50.1+ supports four deployment tiers, each building on the previous. Set ``global.tier`` in your values file to control which services are deployed:
+
+.. code-block:: yaml
+
+    global:
+      tier: "full"   # platform | analytics | viz | full
+
+Each tier includes all capabilities of the previous tiers:
+
+=========== ============================================================================== ============
+Tier        Description                                                                    GPU Required
+=========== ============================================================================== ============
+``platform``  ``postgres`` + ``nexus``. Auth provider, foundation for Louie or other          No
+              integrations. Minimum tier, services in the same namespace connect internally
+              via ``http://nexus:8000``. For external access use port-forward or Ingress.
+``analytics`` ``platform`` + ``caddy``, ``nginx``, ``redis``, ``dask-scheduler``,              Yes
+              ``dask-cuda-worker``, ``forge-etl-python``. Public API access, GPU compute,
+              ETL processing and GFQL graph queries.
+``viz``       ``analytics`` + ``streamgl-sessions``, ``streamgl-gpu``, ``streamgl-viz``.       Yes
+              Interactive graph visualization with WebGL rendering and real-time GPU layout.
+``full``      ``viz`` + ``pivot``, ``notebook``, ``graph-app-kit`` (public/private).           Yes
+              Investigation tools (Pivot), Jupyter notebooks and Streamlit dashboards.
+              **Default tier**.
+=========== ============================================================================== ============
+
+Services per tier
+^^^^^^^^^^^^^^^^^
+
+========================= ========== ========== ==== =====
+Service                   platform   analytics  viz  full
+========================= ========== ========== ==== =====
+``postgres`` (pg-cluster) X          X          X    X
+``nexus``                 X          X          X    X
+``caddy``                            X          X    X
+``nginx``                            X          X    X
+``redis``                            X          X    X
+``dask-scheduler``                   X          X    X
+``dask-cuda-worker``                 X          X    X
+``forge-etl-python``                 X          X    X
+``streamgl-sessions``                           X    X
+``streamgl-gpu``                                X    X
+``streamgl-viz``                                X    X
+``pivot``                                            X
+``notebook``                                         X
+``graph-app-kit-public``                             X
+``graph-app-kit-private``                            X
+========================= ========== ========== ==== =====
+
+PVCs per tier
+^^^^^^^^^^^^^
+
+============================== ========== ========== ==== =====
+PVC                            platform   analytics  viz  full
+============================== ========== ========== ==== =====
+``data-mount`` (64Gi)          X          X          X    X
+``local-media-mount`` (4Gi)    X          X          X    X
+``uploads-files`` (40Gi)                  X          X    X
+``gak-public`` (4Gi)                                      X
+``gak-private`` (4Gi)                                     X
+============================== ========== ========== ==== =====
+
+Tiers and telemetry
+^^^^^^^^^^^^^^^^^^^
+
+Telemetry is orthogonal to the deployment tier. It is controlled independently via ``global.ENABLE_OPEN_TELEMETRY`` (default: ``true``). When enabled, the telemetry stack (otel-collector, Grafana, Prometheus, Jaeger, DCGM exporter, node exporter) deploys alongside whichever tier is selected. Services that are deployed export traces and metrics automatically; services not included in the tier simply don't emit data.
+
 Install Graphistry
 ------------------
 
@@ -254,6 +323,7 @@ When updating, preserve existing volume bindings so that data persists across re
     echo "volumeName:
       dataMount: $(kubectl get pvc data-mount -n graphistry -o jsonpath='{.spec.volumeName}')
       localMediaMount: $(kubectl get pvc local-media-mount -n graphistry -o jsonpath='{.spec.volumeName}')
+      uploadsFiles: $(kubectl get pvc uploads-files -n graphistry -o jsonpath='{.spec.volumeName}')
       gakPublic: $(kubectl get pvc gak-public -n graphistry -o jsonpath='{.spec.volumeName}')
       gakPrivate: $(kubectl get pvc gak-private -n graphistry -o jsonpath='{.spec.volumeName}')"
 

--- a/docs/source/configure-storageclass.rst
+++ b/docs/source/configure-storageclass.rst
@@ -104,6 +104,10 @@ PVC                            Used By Services
 ``uploads-files``              nginx, forge-etl-python
 ============================== ==============================================================================================
 
+.. note::
+
+   The notebook service mounts ``data-mount`` at ``/home/graphistry/notebooks/`` (subPath: ``notebooks``). Only files saved under this directory persist across redeployments. The default demo notebooks at ``/home/graphistry/demos/`` are baked into the Docker image and reset when the image tag changes. To preserve your work, save or copy notebooks to ``/home/graphistry/notebooks/``.
+
 
 Postgres Storage
 ----------------
@@ -128,6 +132,7 @@ To preserve volume bindings across redeployments, generate the ``volumeName`` bl
     echo "volumeName:
       dataMount: $(kubectl get pvc data-mount -n graphistry -o jsonpath='{.spec.volumeName}')
       localMediaMount: $(kubectl get pvc local-media-mount -n graphistry -o jsonpath='{.spec.volumeName}')
+      uploadsFiles: $(kubectl get pvc uploads-files -n graphistry -o jsonpath='{.spec.volumeName}')
       gakPublic: $(kubectl get pvc gak-public -n graphistry -o jsonpath='{.spec.volumeName}')
       gakPrivate: $(kubectl get pvc gak-private -n graphistry -o jsonpath='{.spec.volumeName}')"
 
@@ -138,6 +143,7 @@ Copy the output into your values file, for example:
     volumeName:
       dataMount: pvc-91a0b93-f7c9-471c-b00b-ab6dfb59885f
       localMediaMount: pvc-89ac98bf-2d96-4690-9a24-fb19a93d2c43
+      uploadsFiles: pvc-a417fc34-2128-4824-99de-a3267e21e4dc
       gakPublic: pvc-97h36989-9cfa-4058-b420-fbcab0c3dc7f
       gakPrivate: pvc-9ase0164-e483-4b54-62a5-79a7181071e5
 
@@ -148,3 +154,19 @@ Then run the normal upgrade command:
     helm upgrade -i g-chart ./charts/graphistry-helm \
         --values ./your-values.yaml \
         --namespace graphistry --create-namespace
+
+If pods stay in ``Pending`` state after a reinstall, the PVs may have a stale ``claimRef``. This commonly happens when you ``helm uninstall`` the Graphistry chart and then reinstall it: the StorageClass uses ``reclaimPolicy: Retain``, so the PVs survive the uninstall but remain bound to the old (now deleted) PVCs. The new PVCs cannot bind to those PVs until the stale ``claimRef`` is cleared.
+
+After ``helm uninstall``, PVs take up to 60 seconds to transition from ``Bound`` to ``Released``. Watch for the transition before clearing the claimRef:
+
+.. code-block:: shell-session
+
+    # Watch until PVs show Released (Ctrl+C once you see them)
+    kubectl get pv --watch | grep Released
+
+    # Then clear the stale claimRef
+    kubectl get pv -o json | \
+        jq -r '.items[] | select(.status.phase=="Released") | select(.spec.claimRef.namespace=="graphistry") | .metadata.name' | \
+        xargs -I {} kubectl patch pv {} -p '{"spec":{"claimRef": null}}'
+
+Then re-run the helm upgrade. The PVCs will bind to the existing PVs via the ``volumeName`` field, preserving your data.

--- a/docs/source/graphistry-helm-docs.rst
+++ b/docs/source/graphistry-helm-docs.rst
@@ -77,6 +77,75 @@ Create the secret above as gak-secret.yaml and run the following command to crea
 
 Once you have Created the user provided in the secret in Graphistry, Graph App Kit will display dashboards.
 
+Deployment Tiers
+----------------
+
+Graphistry v2.50.1+ supports four deployment tiers, each building on the previous. Set ``global.tier`` in your values file to control which services are deployed:
+
+.. code-block:: yaml
+
+    global:
+      tier: "full"   # platform | analytics | viz | full
+
+Each tier includes all capabilities of the previous tiers:
+
+=========== ============================================================================== ============
+Tier        Description                                                                    GPU Required
+=========== ============================================================================== ============
+``platform``  ``postgres`` + ``nexus``. Auth provider, foundation for Louie or other          No
+              integrations. Minimum tier, services in the same namespace connect internally
+              via ``http://nexus:8000``. For external access use port-forward or Ingress.
+``analytics`` ``platform`` + ``caddy``, ``nginx``, ``redis``, ``dask-scheduler``,              Yes
+              ``dask-cuda-worker``, ``forge-etl-python``. Public API access, GPU compute,
+              ETL processing and GFQL graph queries.
+``viz``       ``analytics`` + ``streamgl-sessions``, ``streamgl-gpu``, ``streamgl-viz``.       Yes
+              Interactive graph visualization with WebGL rendering and real-time GPU layout.
+``full``      ``viz`` + ``pivot``, ``notebook``, ``graph-app-kit`` (public/private).           Yes
+              Investigation tools (Pivot), Jupyter notebooks and Streamlit dashboards.
+              **Default tier**.
+=========== ============================================================================== ============
+
+Services per tier
+^^^^^^^^^^^^^^^^^
+
+========================= ========== ========== ==== =====
+Service                   platform   analytics  viz  full
+========================= ========== ========== ==== =====
+``postgres`` (pg-cluster) X          X          X    X
+``nexus``                 X          X          X    X
+``caddy``                            X          X    X
+``nginx``                            X          X    X
+``redis``                            X          X    X
+``dask-scheduler``                   X          X    X
+``dask-cuda-worker``                 X          X    X
+``forge-etl-python``                 X          X    X
+``streamgl-sessions``                           X    X
+``streamgl-gpu``                                X    X
+``streamgl-viz``                                X    X
+``pivot``                                            X
+``notebook``                                         X
+``graph-app-kit-public``                             X
+``graph-app-kit-private``                            X
+========================= ========== ========== ==== =====
+
+PVCs per tier
+^^^^^^^^^^^^^
+
+============================== ========== ========== ==== =====
+PVC                            platform   analytics  viz  full
+============================== ========== ========== ==== =====
+``data-mount`` (64Gi)          X          X          X    X
+``local-media-mount`` (4Gi)    X          X          X    X
+``uploads-files`` (40Gi)                  X          X    X
+``gak-public`` (4Gi)                                      X
+``gak-private`` (4Gi)                                     X
+============================== ========== ========== ==== =====
+
+Tiers and telemetry
+^^^^^^^^^^^^^^^^^^^
+
+Telemetry is orthogonal to the deployment tier. It is controlled independently via ``global.ENABLE_OPEN_TELEMETRY`` (default: ``true``). When enabled, the telemetry stack (otel-collector, Grafana, Prometheus, Jaeger, DCGM exporter, node exporter) deploys alongside whichever tier is selected. Services that are deployed export traces and metrics automatically; services not included in the tier simply don't emit data.
+
 Configuring Graphistry
 ----------------------
 
@@ -88,12 +157,13 @@ There are some deployment-specific values which must be set, such as **global.pr
         volumeName:
             dataMount: pvc-91a0b93-f7c9-471c-b00b-ab6dfb59885f
             localMediaMount: pvc-89ac98bf-2d96-4690-9a24-fb19a93d2c43
+            uploadsFiles: pvc-a417fc34-2128-4824-99de-a3267e21e4dc
             gakPublic: pvc-97h36989-9cfa-4058-b420-fbcab0c3dc7f
             gakPrivate: pvc-9ase0164-e483-4b54-62a5-79a7181071e5
 
         global:
             provisioner: <your-csi-provisioner>
-            tag: v2.50.0
+            tag: v2.50.1
             storageClassNameOverride: ""
             nodeSelector:
               nvidia.com/gpu.present: "true"
@@ -127,6 +197,7 @@ To preserve volume bindings across redeployments, generate the ``volumeName`` bl
         echo "volumeName:
           dataMount: $(kubectl get pvc data-mount -n graphistry -o jsonpath='{.spec.volumeName}')
           localMediaMount: $(kubectl get pvc local-media-mount -n graphistry -o jsonpath='{.spec.volumeName}')
+          uploadsFiles: $(kubectl get pvc uploads-files -n graphistry -o jsonpath='{.spec.volumeName}')
           gakPublic: $(kubectl get pvc gak-public -n graphistry -o jsonpath='{.spec.volumeName}')
           gakPrivate: $(kubectl get pvc gak-private -n graphistry -o jsonpath='{.spec.volumeName}')"
 
@@ -137,6 +208,7 @@ Copy the output into your values file under the ``volumeName`` section, for exam
         volumeName:
             dataMount: pvc-91a0b93-f7c9-471c-b00b-ab6dfb59885f
             localMediaMount: pvc-89ac98bf-2d96-4690-9a24-fb19a93d2c43
+            uploadsFiles: pvc-a417fc34-2128-4824-99de-a3267e21e4dc
             gakPublic: pvc-97h36989-9cfa-4058-b420-fbcab0c3dc7f
             gakPrivate: pvc-9ase0164-e483-4b54-62a5-79a7181071e5
 
@@ -686,7 +758,7 @@ The following table lists the configurable parameters of the Graphistry-helm-cha
 
    * - ``global.tag``                                    
      -                                                                                                     
-     - ``"v2.50.0"``                                    
+     - ``"v2.50.1"``                                    
 
 
 

--- a/docs/source/values-override.rst
+++ b/docs/source/values-override.rst
@@ -48,7 +48,7 @@ Below is an example ``values.yaml`` for a single-node deployment:
       nodeSelector:
         nvidia.com/gpu.present: "true"
 
-      tag: v2.50.0
+      tag: v2.50.1
       imagePullPolicy: Always
       imagePullSecrets:
         - name: docker-secret-prod
@@ -83,7 +83,7 @@ The following values must be set for a working deployment:
 * **global.imagePullSecrets** -- Docker registry credentials for pulling Graphistry images
 * **global.provisioner** -- CSI storage provisioner for your platform (e.g., ``rancher.io/local-path``, ``pd.csi.storage.gke.io``)
 * **global.nodeSelector** -- Label selector to schedule pods on GPU nodes
-* **global.tag** -- Graphistry version tag (e.g., ``v2.50.0``)
+* **global.tag** -- Graphistry version tag (e.g., ``v2.50.1``)
 
 Optional but Recommended
 -------------------------


### PR DESCRIPTION
## Summary

- **Deployment tiers**: New `global.tier` value (platform, analytics, viz, full) controls which services deploy. Each tier is a superset of the previous. Platform deploys only nexus + postgres (auth foundation for Louie). Full is the default (backward compatible).
- **Service dependencies aligned with compose release.yml**: Removed incorrect nexus bottleneck from startup chain. Added missing dask-cuda-worker and redis waits to forge-etl-python. Faster startup, correct dependency ordering.
- **Static file PVC sharing**: Replaced heavy nginx init containers (~14GB image pulls) with PVC subpath sharing from streamgl-viz and pivot. Nginx has zero init containers.
- **NOTES.txt rewrite**: Tier-aware output with prerequisites, deployed services, CUDA/driver info, telemetry endpoints, volumes, and redeployment commands.
- **uploads-files volumeName fix**: PVC could not rebind on redeployment (data loss risk). Now consistent with the other 4 PVCs.
- **dask-cuda-worker failureThreshold**: 1 -> 3, fixing unnecessary restarts during startup race.
- **Documentation**: Deployment Tiers section added to all platform READMEs, Sphinx docs, and README.md. PV claimRef --watch instructions, notebook persistence note, k3s --data-dir flag, driver tables with R595.
- **Version**: v2.50.1, chart 0.4.3, RAPIDS 26.02, CUDA 12/13.

## Test plan

- [x] `helm template` renders all 4 tiers x telemetry on/off (8 combinations, zero errors)
- [x] k3s: platform tier deployed and verified (nexus + postgres only)
- [x] k3s: analytics tier deployed, PyGraphistry upload + GFQL verified, telemetry metrics exported
- [x] k3s: viz tier deployed, graph rendering verified (WebGL + Arrow batches)
- [x] k3s: full tier deployed, notebook + gak + pivot verified
- [x] k3s: redeployment with volumeName preservation verified (PV rebinding works)
- [x] GKE: full tier deployed on T4 with R570 driver
- [x] CUDA 12 verified on R570, R575, R580, R590, R595
- [x] CUDA 13 verified on R590, R595